### PR TITLE
feat: Implement customizable column color themes for Kanban board

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -254,3 +254,43 @@ button:focus-visible {
   border: 1px solid var(--info-border-color, #bee5eb);
 }
 */
+
+/* Kanban Column Theme Styles */
+
+/* Default theme relies on existing .kanban-column styles for background
+   and h3 styles, but we can be explicit if needed or if those defaults change.
+   The .kanban-column class already sets:
+   background-color: var(--surface-color-secondary, #f0f0f0);
+   And its h3 child has:
+   color: var(--text-color-strong);
+   So, .kanban-column-theme-default might not need explicit rules if these are sufficient.
+   For clarity, we can add them.
+*/
+
+.kanban-column-theme-default {
+  background-color: var(--surface-color-secondary, #f0f0f0); /* Default from .kanban-column */
+}
+
+.kanban-column-theme-default h3 {
+  color: var(--text-color-strong, #000); /* Default from .kanban-column h3 */
+}
+
+.kanban-column-theme-pastel {
+  background-color: #e9e7fd; /* Light lavender/periwinkle */
+}
+
+.kanban-column-theme-pastel h3 {
+  color: #5c5493; /* Darker muted purple */
+}
+
+.kanban-column-theme-ocean {
+  background-color: #d4f0f0; /* Light teal/cyan */
+}
+
+.kanban-column-theme-ocean h3 {
+  color: #3b706a; /* Darker muted teal */
+}
+
+/* Ensure column titles have enough contrast with new backgrounds. */
+/* Card backgrounds (.kanban-card) are white by default (unless complete),
+   which should generally provide good contrast with these column backgrounds. */

--- a/src/types.ts
+++ b/src/types.ts
@@ -54,3 +54,5 @@ export interface KidKanbanConfig {
   selectedPeriod: KanbanPeriod;
   columns: KanbanColumn[];
 }
+
+export type ColumnThemeOption = 'default' | 'pastel' | 'ocean';

--- a/src/ui/kanban_components/KanbanColumn.tsx
+++ b/src/ui/kanban_components/KanbanColumn.tsx
@@ -1,20 +1,40 @@
 // src/ui/kanban_components/KanbanColumn.tsx
 import React from 'react';
-import type { KanbanColumn as KanbanColumnType, ChoreInstance, ChoreDefinition } from '../../types';
+// Import ColumnThemeOption from types
+import type { KanbanColumn as KanbanColumnType, ChoreInstance, ChoreDefinition, ColumnThemeOption } from '../../types';
 import KanbanCard from './KanbanCard';
 
 interface KanbanColumnProps {
   column: KanbanColumnType;
   getDefinitionForInstance: (instance: ChoreInstance) => ChoreDefinition | undefined;
+  theme: ColumnThemeOption; // Add theme prop
 }
 
-const KanbanColumn: React.FC<KanbanColumnProps> = ({ column, getDefinitionForInstance }) => {
+const KanbanColumn: React.FC<KanbanColumnProps> = ({ column, getDefinitionForInstance, theme }) => {
   return (
-    <div className="kanban-column" style={{ border: '1px solid #eee', padding: '10px', borderRadius: '5px', minWidth: '250px', backgroundColor: '#f9f9f9' }}>
-      <h3 style={{ borderBottom: '1px solid #ddd', paddingBottom: '5px', marginBottom: '10px' }}>{column.title}</h3>
+    <div
+      className={`kanban-column kanban-column-theme-${theme}`} // Dynamically set class
+      style={{
+        // border: '1px solid #eee', // Will be managed by theme CSS or base .kanban-column style
+        padding: '10px',
+        borderRadius: 'var(--border-radius-lg)', // Keep or manage via theme
+        minWidth: '250px',
+        // backgroundColor: '#f9f9f9', // Removed, will be handled by theme CSS
+        boxShadow: '0 2px 4px rgba(0,0,0,0.05)' // Keep or manage via theme/base
+      }}
+    >
+      <h3 style={{
+          // borderBottom: '1px solid #ddd', // Will be managed by theme CSS or base .kanban-column h3 style
+          paddingBottom: '5px',
+          marginBottom: '10px'
+          // color: var(--text-color-strong) // Removed, will be handled by theme CSS
+        }}
+      >
+        {column.title}
+      </h3>
       <div className="kanban-cards-container" style={{ minHeight: '100px' }}>
         {column.chores.length > 0 ? (
-          column.chores.map(instance => { // This is now an array of ChoreInstance
+          column.chores.map(instance => {
             const definition = getDefinitionForInstance(instance);
             if (!definition) {
               console.warn(`Definition not found for instance ${instance.id}`);
@@ -23,8 +43,8 @@ const KanbanColumn: React.FC<KanbanColumnProps> = ({ column, getDefinitionForIns
             return (
               <KanbanCard
                 key={instance.id}
-                instance={instance} // Pass instance
-                definition={definition} // Pass definition
+                instance={instance}
+                definition={definition}
               />
             );
           })

--- a/src/ui/kanban_components/KidKanbanBoard.tsx
+++ b/src/ui/kanban_components/KidKanbanBoard.tsx
@@ -1,7 +1,8 @@
 // src/ui/kanban_components/KidKanbanBoard.tsx
 import React, { useState, useEffect, useMemo } from 'react';
 import { useChoresContext } from '../../contexts/ChoresContext';
-import type { ChoreDefinition, ChoreInstance, KanbanPeriod, KanbanColumn as KanbanColumnType } from '../../types';
+// Import ColumnThemeOption from types
+import type { ChoreDefinition, ChoreInstance, KanbanPeriod, KanbanColumn as KanbanColumnType, ColumnThemeOption } from '../../types';
 import KanbanColumn from './KanbanColumn';
 import { getTodayDateString, getWeekRange, getMonthRange } from '../../utils/dateUtils';
 
@@ -9,6 +10,7 @@ import { getTodayDateString, getWeekRange, getMonthRange } from '../../utils/dat
 type RewardFilterOption = 'any' | 'has_reward' | 'no_reward';
 type SortByOption = 'instanceDate' | 'title' | 'rewardAmount';
 type SortDirectionOption = 'asc' | 'desc';
+// ColumnThemeOption is now imported from ../../types
 
 interface KidKanbanBoardProps {
   kidId: string;
@@ -23,6 +25,15 @@ const KidKanbanBoard: React.FC<KidKanbanBoardProps> = ({ kidId }) => {
   const [rewardFilter, setRewardFilter] = useState<RewardFilterOption>('any');
   const [sortBy, setSortBy] = useState<SortByOption>('instanceDate');
   const [sortDirection, setSortDirection] = useState<SortDirectionOption>('asc');
+  const [selectedColumnTheme, setSelectedColumnTheme] = useState<ColumnThemeOption>(() => {
+    const storedTheme = localStorage.getItem('kanban_columnTheme') as ColumnThemeOption | null;
+    return storedTheme || 'default';
+  });
+
+  // Effect to save theme to localStorage
+  useEffect(() => {
+    localStorage.setItem('kanban_columnTheme', selectedColumnTheme);
+  }, [selectedColumnTheme]);
 
   // 1. Determine current period's start and end dates
   const currentPeriodDateRange = useMemo(() => {
@@ -191,6 +202,20 @@ const KidKanbanBoard: React.FC<KidKanbanBoardProps> = ({ kidId }) => {
             {sortDirection === 'asc' ? ' ↑' : ' ↓'}
           </button>
         </div>
+
+        <div>
+          <label htmlFor="columnThemeSelect" style={{ marginRight: '5px' }}>Column Theme:</label>
+          <select
+            id="columnThemeSelect"
+            value={selectedColumnTheme}
+            onChange={(e) => setSelectedColumnTheme(e.target.value as ColumnThemeOption)}
+            style={{ padding: '5px' }}
+          >
+            <option value="default">Default</option>
+            <option value="pastel">Pastel</option>
+            <option value="ocean">Ocean</option>
+          </select>
+        </div>
       </div>
 
       <div className="kanban-columns" style={{ display: 'flex', gap: '10px' }}>
@@ -199,6 +224,7 @@ const KidKanbanBoard: React.FC<KidKanbanBoardProps> = ({ kidId }) => {
             key={col.id}
             column={col}
             getDefinitionForInstance={getDefinitionForInstance}
+            theme={selectedColumnTheme} // Pass the selected theme state
           />
         ))}
         {columns.every(col => col.chores.length === 0) && <p>No chores to display for this period.</p>}


### PR DESCRIPTION
Adds the ability for you to select different color themes for the Kanban board columns. The selected theme is persisted across sessions using localStorage.

Key changes:
- **Theme Definition:**
    - Defined three themes: 'Default', 'Pastel', and 'Ocean', each with specific background and header text colors.

- **State Management (`KidKanbanBoard.tsx`):**
    - Added `selectedColumnTheme` state to manage the currently active theme.

- **UI for Theme Selection (`KidKanbanBoard.tsx`):**
    - Added a dropdown menu to allow you to select a theme.

- **Theme Application (`KanbanColumn.tsx`):**
    - `selectedColumnTheme` is passed as a prop to `KanbanColumn`.
    - `KanbanColumn` dynamically applies a CSS class (e.g., `kanban-column-theme-pastel`) based on the theme.
    - `ColumnThemeOption` type was moved to `src/types.ts`.

- **CSS for Themes (`src/index.css`):**
    - Added CSS rules to define the `background-color` and `h3` text `color` for each theme class.

- **Persistence (`KidKanbanBoard.tsx`):**
    - The `selectedColumnTheme` is saved to `localStorage` on change and loaded on component initialization.

- **Testing:**
    - I prepared a detailed manual testing plan to verify theme selection, application, persistence, and interactions.