### PR TITLE
feat(kanban): Implement CSS themes for Kanban columns

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -672,3 +672,68 @@ h6 { font-size: var(--font-size-lg); font-weight: var(--font-weight-medium); }
   background-color: var(--surface-color-hover);
   border-color: var(--primary-color-dark);
 }
+
+/* Kanban Board Styles */
+.kanban-column {
+  padding: 10px;
+  border-radius: var(--border-radius-lg, 8px);
+  box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+  min-width: 280px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px; /* Space between header and cards container */
+}
+
+.kanban-column h3 {
+  padding-bottom: 10px;
+  margin-bottom: 0;
+  margin-top: 0;
+  font-size: 1.1em;
+  font-weight: 600;
+}
+
+.kanban-cards-container {
+  min-height: 100px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px; /* Space between cards */
+}
+
+.kanban-card {
+  border: 1px solid #ddd;
+  padding: 10px;
+  border-radius: var(--border-radius-md, 6px);
+  background-color: #fff;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.03);
+}
+
+/* Kanban Column Themes */
+.kanban-column-theme-default {
+  background-color: #f0f2f5; /* Light grey background */
+  border: 1px solid #d9d9d9;
+}
+
+.kanban-column-theme-default h3 {
+  color: #333; /* Dark grey text for header */
+  border-bottom: 1px solid #d9d9d9;
+}
+
+.kanban-column-theme-pastel {
+  background-color: #e6e0f8; /* Light pastel lavender */
+  border: 1px solid #c9c0e0; /* Slightly darker pastel border */
+}
+
+.kanban-column-theme-pastel h3 {
+  color: #5c4b8b; /* Darker purple for text, good contrast */
+  border-bottom: 1px solid #c9c0e0;
+}
+
+.kanban-column-theme-ocean {
+  background-color: #d4f1f9; /* Light sky blue / shallow water */
+  border: 1px solid #a9d8e6; /* Slightly darker blue border */
+}
+
+.kanban-column-theme-ocean h3 {
+  color: #005f73; /* Deep blue/teal for text */
+  border-bottom: 1px solid #a9d8e6;
+}


### PR DESCRIPTION
Adds CSS styles for 'default', 'pastel', and 'ocean' themes for the Kanban board columns. This allows you to select a visual theme for the columns in the KidKanbanBoard view.

The following changes were made:
- Added base CSS styles for `.kanban-column` and `.kanban-card` components to `src/styles.css` for a consistent foundation.
- Implemented `.kanban-column-theme-default` with a light grey background and dark grey text.
- Implemented `.kanban-column-theme-pastel` with a light lavender background and darker purple text.
- Implemented `.kanban-column-theme-ocean` with a light sky blue background and deep blue/teal text.

These styles are applied dynamically based on the theme selected in `KidKanbanBoard.tsx` and stored in localStorage.