### PR TITLE
feat(kanban): Persist custom chore order within columns

### DIFF
--- a/FEATURE_TRACKING.md
+++ b/FEATURE_TRACKING.md
@@ -252,6 +252,9 @@ This document tracks the status, priority, and progress of key features and task
     -   Status: Done
     -   Priority: High (Enhancement to chore tracking)
     -   Notes: Provides a visual Kanban interface (`KanbanView.tsx`) for a selected kid's chores. Displays chores in 'Active' and 'Completed' columns for daily, weekly, or monthly periods. Supports drag-and-drop to reorder chores and move them between columns (which updates their completion status). Features include column theming, filtering by reward status, and sorting by due date, title, or reward. Comprehensive tests (unit, component, integration) and JSDoc comments have been added for this feature.
+    -   **Sub-Feature**: Persist Custom Chore Order.
+        -   Status: Done
+        -   Notes: Allows users to manually reorder chores within a Kanban column via drag-and-drop. This custom order is saved (in localStorage via ChoresContext) and reapplied when the board is viewed with the "My Order / Due Date" sort setting. Applying an explicit sort (e.g., by Title, Reward) will clear the custom order for the currently viewed columns, allowing the explicit sort to take precedence.
 
 ### Task 7.2: Earning Integration (Chore Tracking)
 *Led by Google Calendar / Google Tasks / AI/ML Team*

--- a/src/contexts/ChoresContext.test.tsx
+++ b/src/contexts/ChoresContext.test.tsx
@@ -1,0 +1,151 @@
+// src/contexts/ChoresContext.test.tsx
+import { renderHook, act } from '@testing-library/react';
+import { ChoresProvider, useChoresContext, KanbanChoreOrders } from './ChoresContext';
+import React, { ReactNode } from 'react';
+import { vi } from 'vitest';
+import { FinancialContext, FinancialContextType } from './FinancialContext'; // ChoresContext depends on FinancialContext
+
+// Mock localStorage
+const localStorageMockFactory = () => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: vi.fn((key: string) => store[key] || null),
+    setItem: vi.fn((key: string, value: string) => { store[key] = value.toString(); }),
+    clear: vi.fn(() => { store = {}; }),
+    removeItem: vi.fn((key: string) => { delete store[key]; }),
+    getStore: () => store, // Helper for direct inspection if needed
+  };
+};
+let localStorageMock = localStorageMockFactory();
+
+// Mock FinancialContext as ChoresProvider uses it
+const mockAddKidReward = vi.fn();
+const mockFinancialContextValue: FinancialContextType = {
+  transactions: [],
+  addTransaction: vi.fn(),
+  addKidReward: mockAddKidReward,
+  getTransactionsForKid: vi.fn(() => []),
+  getFundsForKid: vi.fn(() => 0),
+  loading: false,
+  error: null,
+};
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <FinancialContext.Provider value={mockFinancialContextValue}>
+    <ChoresProvider>{children}</ChoresProvider>
+  </FinancialContext.Provider>
+);
+
+
+describe('ChoresContext - Kanban Chore Orders', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Reset localStorage for each test
+    localStorageMock = localStorageMockFactory();
+    Object.defineProperty(window, 'localStorage', {
+      value: localStorageMock,
+      writable: true, // Ensure it can be reconfigured for each test
+      configurable: true,
+    });
+  });
+
+  test('initializes kanbanChoreOrders as an empty object if localStorage is empty', () => {
+    localStorageMock.getItem.mockReturnValueOnce(null);
+    const { result } = renderHook(() => useChoresContext(), { wrapper });
+    expect(result.current.kanbanChoreOrders).toEqual({});
+  });
+
+  test('initializes kanbanChoreOrders from localStorage if data exists', () => {
+    const storedOrders: KanbanChoreOrders = {
+      'kid1-daily_active': ['choreInst1', 'choreInst2'],
+    };
+    localStorageMock.getItem.mockReturnValueOnce(JSON.stringify(storedOrders));
+    const { result } = renderHook(() => useChoresContext(), { wrapper });
+    expect(result.current.kanbanChoreOrders).toEqual(storedOrders);
+  });
+
+  test('handles invalid JSON in localStorage gracefully for kanbanChoreOrders', () => {
+    localStorageMock.getItem.mockReturnValueOnce("invalid json");
+    // Spy on console.error to check for error logging
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { result } = renderHook(() => useChoresContext(), { wrapper });
+
+    expect(result.current.kanbanChoreOrders).toEqual({}); // Should default to empty object
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "Error parsing kanbanChoreOrders from localStorage:",
+      expect.any(SyntaxError) // Or whatever error JSON.parse throws
+    );
+    consoleErrorSpy.mockRestore();
+  });
+
+
+  test('updateKanbanChoreOrder adds a new order and updates localStorage', () => {
+    const { result } = renderHook(() => useChoresContext(), { wrapper });
+    const kidId = 'kid1';
+    const columnIdentifier = 'daily_active';
+    const orderedChoreIds = ['choreInst3', 'choreInst1'];
+    const expectedKey = `${kidId}-${columnIdentifier}`;
+
+    act(() => {
+      result.current.updateKanbanChoreOrder(kidId, columnIdentifier, orderedChoreIds);
+    });
+
+    expect(result.current.kanbanChoreOrders[expectedKey]).toEqual(orderedChoreIds);
+    expect(localStorageMock.setItem).toHaveBeenCalledWith(
+      'kanbanChoreOrders',
+      JSON.stringify({ [expectedKey]: orderedChoreIds })
+    );
+  });
+
+  test('updateKanbanChoreOrder updates an existing order and localStorage', () => {
+    const initialOrders: KanbanChoreOrders = {
+      'kid1-daily_active': ['choreInst1', 'choreInst2'],
+    };
+    localStorageMock.getItem.mockReturnValueOnce(JSON.stringify(initialOrders));
+    const { result } = renderHook(() => useChoresContext(), { wrapper });
+
+    const kidId = 'kid1';
+    const columnIdentifier = 'daily_active';
+    const newOrderedChoreIds = ['choreInst2', 'choreInst1', 'choreInst4'];
+    const expectedKey = `${kidId}-${columnIdentifier}`;
+
+    act(() => {
+      result.current.updateKanbanChoreOrder(kidId, columnIdentifier, newOrderedChoreIds);
+    });
+
+    expect(result.current.kanbanChoreOrders[expectedKey]).toEqual(newOrderedChoreIds);
+    expect(localStorageMock.setItem).toHaveBeenCalledWith(
+      'kanbanChoreOrders',
+      JSON.stringify({ [expectedKey]: newOrderedChoreIds })
+    );
+  });
+
+  test('updateKanbanChoreOrder clears an order if orderedChoreIds is empty and updates localStorage', () => {
+    const initialOrders: KanbanChoreOrders = {
+      'kid1-daily_active': ['choreInst1', 'choreInst2'],
+      'kid1-weekly_active': ['choreInstA', 'choreInstB'],
+    };
+    localStorageMock.getItem.mockReturnValueOnce(JSON.stringify(initialOrders));
+    const { result } = renderHook(() => useChoresContext(), { wrapper });
+
+    const kidId = 'kid1';
+    const columnIdentifier = 'daily_active';
+    const emptyOrderedChoreIds: string[] = [];
+    const keyToClear = `${kidId}-${columnIdentifier}`;
+
+    act(() => {
+      result.current.updateKanbanChoreOrder(kidId, columnIdentifier, emptyOrderedChoreIds);
+    });
+
+    expect(result.current.kanbanChoreOrders[keyToClear]).toBeUndefined();
+    expect(result.current.kanbanChoreOrders['kid1-weekly_active']).toEqual(['choreInstA', 'choreInstB']); // Other orders remain
+
+    const expectedStoredOrders = { ...initialOrders };
+    delete expectedStoredOrders[keyToClear];
+    expect(localStorageMock.setItem).toHaveBeenCalledWith(
+      'kanbanChoreOrders',
+      JSON.stringify(expectedStoredOrders)
+    );
+  });
+});

--- a/src/ui/kanban_components/KidKanbanBoard.test.tsx
+++ b/src/ui/kanban_components/KidKanbanBoard.test.tsx
@@ -69,16 +69,21 @@ vi.mock('@dnd-kit/sortable', async (importOriginal) => {
 // Mock ChoresContext
 const mockGenerateInstancesForPeriod = vi.fn();
 const mockToggleChoreInstanceComplete = vi.fn();
+const mockUpdateKanbanChoreOrder = vi.fn(); // Mock for the new function
 
 const mockChoreDefinitions: ChoreDefinition[] = [
   { id: 'def1', title: 'Walk the Dog', assignedKidId: 'kid1', rewardAmount: 5, subTasks:[], tags:[], recurrenceType: null, createdAt: '2023-01-01', updatedAt: '2023-01-01', hour:10, minute:0, timeOfDay:'AM' },
   { id: 'def2', title: 'Clean Room', assignedKidId: 'kid1', rewardAmount: 10, subTasks:[], tags:[], recurrenceType: null, createdAt: '2023-01-01', updatedAt: '2023-01-01', hour:10, minute:0, timeOfDay:'AM' },
   { id: 'def3', title: 'Do Homework', assignedKidId: 'kid1', rewardAmount: 0, subTasks:[], tags:[], recurrenceType: null, createdAt: '2023-01-01', updatedAt: '2023-01-01', hour:10, minute:0, timeOfDay:'AM' },
   { id: 'def4', title: 'Wash Dishes', assignedKidId: 'kid2', rewardAmount: 3, subTasks:[], tags:[], recurrenceType: null, createdAt: '2023-01-01', updatedAt: '2023-01-01', hour:10, minute:0, timeOfDay:'AM' },
+  // For custom order testing, ensure these are assigned to kid1
+  { id: 'def5', title: 'Chore X (for custom order)', assignedKidId: 'kid1', rewardAmount: 1, subTasks:[], tags:[], recurrenceType: null, createdAt: '2023-01-01', updatedAt: '2023-01-01', hour:10, minute:0, timeOfDay:'AM' },
+  { id: 'def6', title: 'Chore Y (for custom order)', assignedKidId: 'kid1', rewardAmount: 1, subTasks:[], tags:[], recurrenceType: null, createdAt: '2023-01-01', updatedAt: '2023-01-01', hour:10, minute:0, timeOfDay:'AM' },
+  { id: 'def7', title: 'Chore Z (for custom order)', assignedKidId: 'kid1', rewardAmount: 1, subTasks:[], tags:[], recurrenceType: null, createdAt: '2023-01-01', updatedAt: '2023-01-01', hour:10, minute:0, timeOfDay:'AM' },
 ];
 
 const today = getTodayDateString();
-let mockChoreInstancesData: ChoreInstance[]; // Mutable for tests
+let mockChoreInstancesData: ChoreInstance[];
 
 const resetMockChoreInstances = () => {
     mockChoreInstancesData = [
@@ -86,28 +91,40 @@ const resetMockChoreInstances = () => {
         { id: 'inst2', choreDefinitionId: 'def2', instanceDate: today, isComplete: true },
         { id: 'inst3', choreDefinitionId: 'def3', instanceDate: today, isComplete: false },
         { id: 'inst4', choreDefinitionId: 'def4', instanceDate: today, isComplete: false },
+        // For custom order testing
+        { id: 'instX', choreDefinitionId: 'def5', instanceDate: today, isComplete: false },
+        { id: 'instY', choreDefinitionId: 'def6', instanceDate: today, isComplete: false },
+        { id: 'instZ', choreDefinitionId: 'def7', instanceDate: today, isComplete: false },
     ];
 };
 
+let mockKanbanChoreOrdersData: Record<string, string[]> = {};
 
-const mockContextValue: ChoresContextType = {
+const resetMockKanbanChoreOrders = () => {
+    mockKanbanChoreOrdersData = {};
+}
+
+const mockContextValueFactory = (customOrders: Record<string, string[]> = {}) => ({
   choreDefinitions: mockChoreDefinitions,
-  get choreInstances() { return mockChoreInstancesData; }, // Use getter to ensure tests get updated data
+  get choreInstances() { return mockChoreInstancesData; },
+  kanbanChoreOrders: customOrders, // Use passed customOrders or default
   generateInstancesForPeriod: mockGenerateInstancesForPeriod,
   toggleChoreInstanceComplete: mockToggleChoreInstanceComplete,
-  getDefinitionById: (id) => mockChoreDefinitions.find(d => d.id === id),
-  getInstancesForDefinition: (defId) => mockChoreInstancesData.filter(i => i.choreDefinitionId === defId),
+  updateKanbanChoreOrder: mockUpdateKanbanChoreOrder,
+  getDefinitionById: (id: string) => mockChoreDefinitions.find(d => d.id === id),
+  getInstancesForDefinition: (defId: string) => mockChoreInstancesData.filter(i => i.choreDefinitionId === defId),
   loadingDefinitions: false, loadingInstances: false, errorDefinitions: null, errorInstances: null,
   addChoreDefinition: vi.fn(), updateChoreDefinition: vi.fn(), deleteChoreDefinition: vi.fn(),
   addChoreInstance: vi.fn(), updateChoreInstance: vi.fn(), deleteChoreInstance: vi.fn(),
   toggleSubTaskComplete: vi.fn(),
-};
+} as ChoresContextType);
 
-const renderKidKanbanBoard = (kidId = 'kid1', context = mockContextValue) => {
-  // Ensure choreInstances in context is fresh for each render if modified by tests
-  const freshContext = {...context, choreInstances: [...mockChoreInstancesData]};
+
+const renderKidKanbanBoard = (kidId = 'kid1', contextValue = mockContextValueFactory(mockKanbanChoreOrdersData) ) => {
+  // Ensure choreInstances in context is fresh for each render
+  const freshContext = {...contextValue, choreInstances: [...mockChoreInstancesData], kanbanChoreOrders: {...contextValue.kanbanChoreOrders}};
   return render(
-    <ChoresContext.Provider value={freshContext}>
+    <ChoresContext.Provider value={freshContext as ChoresContextType}>
       <KidKanbanBoard kidId={kidId} />
     </ChoresContext.Provider>
   );
@@ -277,12 +294,13 @@ describe('KidKanbanBoard - Drag and Drop Event Handling (Part 2)', () => {
     vi.clearAllMocks();
     localStorageMock = localStorageMockFactory(); // Reset localStorage for each test
     Object.defineProperty(window, 'localStorage', { value: localStorageMock, configurable: true });
-    resetMockChoreInstances(); // Reset chore instances for each D&D test
-    dndContextProps = {}; // Reset captured DndContext props
+    resetMockChoreInstances();
+    resetMockKanbanChoreOrders(); // Reset custom orders for each test
+    dndContextProps = {};
 
-    // Default theme for these tests
     localStorageMock.getItem.mockImplementation((key: string) => {
         if (key === 'kanban_columnTheme') return 'default';
+        if (key === 'kanbanChoreOrders') return JSON.stringify(mockKanbanChoreOrdersData); // Use mutable mock data
         return null;
     });
   });
@@ -342,12 +360,19 @@ describe('KidKanbanBoard - Drag and Drop Event Handling (Part 2)', () => {
   });
 
   test('handleDragEnd - reorders items in the same column (active)', () => {
-    renderKidKanbanBoard('kid1'); // inst1, inst3 are active
+    renderKidKanbanBoard('kid1');
     const activeColumnId = 'daily_active';
+    const kidId = 'kid1';
+
+    // Initial active chores for kid1, default order (inst1, inst3, instX, instY, instZ)
+    // Let's say inst1, inst3, instX, instY, instZ are active
+    const initialActiveChores = mockChoreInstancesData.filter(c => c.assignedKidId === kidId && !c.isComplete);
+    const choreIds = initialActiveChores.map(c => c.id);
+
 
     const dragEndEvent: DragEndEvent = {
-      active: createMockActive('inst1', activeColumnId, 0, ['inst1', 'inst3']), // inst1 is dragged
-      over: createMockOver('inst3', activeColumnId, 1, ['inst1', 'inst3']),   // over inst3
+      active: createMockActive('instX', activeColumnId, 2, choreIds),
+      over: createMockOver('instY', activeColumnId, 3, choreIds),
       delta: { x: 0, y: 0 },
       collisions: null,
     };
@@ -357,7 +382,12 @@ describe('KidKanbanBoard - Drag and Drop Event Handling (Part 2)', () => {
     });
 
     const activeColumn = mockKanbanColumn.mock.calls.find(call => call[0].column.id === activeColumnId)[0].column;
-    expect(activeColumn.chores.map((c: ChoreInstance) => c.id)).toEqual(['inst3', 'inst1']);
+    // Expected: inst1, inst3, instY, instX, instZ (if instX moved over instY)
+    // arrayMove(arr, 2, 3) on [inst1, inst3, instX, instY, instZ]
+    // results in [inst1, inst3, instY, instX, instZ]
+    const expectedOrder = ['inst1', 'inst3', 'instY', 'instX', 'instZ'];
+    expect(activeColumn.chores.map((c: ChoreInstance) => c.id)).toEqual(expectedOrder);
+    expect(mockUpdateKanbanChoreOrder).toHaveBeenCalledWith(kidId, activeColumnId, expectedOrder);
   });
 
   test('handleDragEnd - moves item from active to completed column and updates status', () => {
@@ -457,4 +487,101 @@ describe('KidKanbanBoard - Drag and Drop Event Handling (Part 2)', () => {
     expect(finalColumnsState).toEqual(initialColumnsState); // No change to columns
     expect(mockToggleChoreInstanceComplete).not.toHaveBeenCalled();
   });
+
+  test('applies custom order from kanbanChoreOrders when sortBy is "instanceDate"', () => {
+    const kidId = 'kid1';
+    const activeColumnId = 'daily_active';
+    const customOrder = ['instZ', 'instX', 'instY']; // Define a custom order for some of kid1's active chores
+
+    // inst1, inst3 are other active chores for kid1 not in this custom order.
+    // Default active order for kid1 if no custom: inst1, inst3, instX, instY, instZ (by ID or original add order)
+    // Expected with custom: instZ, instX, instY, then inst1, inst3 (appended, sorted by date/default)
+
+    mockKanbanChoreOrdersData[`${kidId}-${activeColumnId}`] = customOrder;
+
+    renderKidKanbanBoard(kidId, mockContextValueFactory(mockKanbanChoreOrdersData));
+
+    // Ensure sort is "My Order / Due Date" (which is 'instanceDate' internally)
+    const sortBySelect = screen.getByLabelText(/Sort by:/i);
+    expect(sortBySelect).toHaveValue('instanceDate');
+
+    const activeColumn = mockKanbanColumn.mock.calls.find(call => call[0].column.id === activeColumnId)[0].column;
+    const renderedOrder = activeColumn.chores.map((c: ChoreInstance) => c.id);
+
+    // Chores in customOrder should appear first, in that order.
+    // Other chores (inst1, inst3) should appear after, sorted by default (e.g., instanceDate or their original order).
+    // Assuming inst1 and inst3 are sorted by their ID here as instanceDate is same for all.
+    const expectedRenderOrder = [...customOrder, 'inst1', 'inst3'];
+    expect(renderedOrder).toEqual(expectedRenderOrder);
+  });
+
+  test('clears custom order for current columns when explicit sort is chosen', async () => {
+    const user = userEvent.setup();
+    const kidId = 'kid1';
+    const activeColumnId = 'daily_active';
+    const completedColumnId = 'daily_completed'; // Assuming this column might also be visible
+
+    // Setup initial custom order
+    mockKanbanChoreOrdersData[`${kidId}-${activeColumnId}`] = ['instZ', 'instX', 'instY'];
+    mockKanbanChoreOrdersData[`${kidId}-${completedColumnId}`] = ['inst2']; // Example for completed
+
+    renderKidKanbanBoard(kidId, mockContextValueFactory(mockKanbanChoreOrdersData));
+
+    // Verify custom order is initially applied (sortBy is 'instanceDate' by default)
+    let activeColumn = mockKanbanColumn.mock.calls.find(call => call[0].column.id === activeColumnId)[0].column;
+    expect(activeColumn.chores.map((c: ChoreInstance) => c.id)).toEqual(['instZ', 'instX', 'instY', 'inst1', 'inst3']);
+
+    // User changes sort to "Title"
+    const sortBySelect = screen.getByLabelText(/Sort by:/i);
+    await user.selectOptions(sortBySelect, 'title');
+
+    // Verify updateKanbanChoreOrder was called to clear orders for visible columns
+    expect(mockUpdateKanbanChoreOrder).toHaveBeenCalledWith(kidId, activeColumnId, []);
+    expect(mockUpdateKanbanChoreOrder).toHaveBeenCalledWith(kidId, completedColumnId, []);
+
+    // Verify chores are now sorted by title (mockKanbanColumn receives chores sorted by KidKanbanBoard's useEffect)
+    // Titles: WalkDog(def1,inst1), CleanRoom(def2,inst2), DoHomework(def3,inst3), ChoreX(def5,instX), ChoreY(def6,instY), ChoreZ(def7,instZ)
+    // Active chores for kid1: inst1, inst3, instX, instY, instZ
+    // Titles: WalkDog, DoHomework, ChoreX, ChoreY, ChoreZ
+    // Expected ASC title order: ChoreX, ChoreY, ChoreZ, DoHomework, WalkDog
+    activeColumn = mockKanbanColumn.mock.calls.find(call => call[0].column.id === activeColumnId)[0].column;
+    expect(activeColumn.chores.map((c: ChoreInstance) => c.id)).toEqual(['instX', 'instY', 'instZ', 'inst3', 'inst1']);
+  });
+
+  test('after explicit sort clears custom order, switching back to "My Order" uses default sort', async () => {
+    const user = userEvent.setup();
+    const kidId = 'kid1';
+    const activeColumnId = 'daily_active';
+
+    mockKanbanChoreOrdersData[`${kidId}-${activeColumnId}`] = ['instZ', 'instX', 'instY']; // Initial custom order
+
+    const contextToUse = mockContextValueFactory(mockKanbanChoreOrdersData);
+    renderKidKanbanBoard(kidId, contextToUse);
+
+    const sortBySelect = screen.getByLabelText(/Sort by:/i);
+
+    // 1. Apply explicit sort (e.g., Title), which should clear custom order for daily_active
+    await user.selectOptions(sortBySelect, 'title');
+    expect(mockUpdateKanbanChoreOrder).toHaveBeenCalledWith(kidId, activeColumnId, []);
+
+    // Simulate the context actually clearing the order for the next step
+    delete mockKanbanChoreOrdersData[`${kidId}-${activeColumnId}`];
+    // Re-render or ensure context update propagates if `renderKidKanbanBoard` doesn't re-read mockKanbanChoreOrdersData directly
+    // For this test, we will assume the effect of updateKanbanChoreOrder has cleared it from the perspective of ChoresContext
+
+    // 2. User switches back to "My Order / Due Date"
+    await user.selectOptions(sortBySelect, 'instanceDate');
+
+    // Verify chores are now in default instanceDate order (all have same date, so original/ID order)
+    // Active kid1 chores: inst1, inst3, instX, instY, instZ
+    // Default order (assuming by ID as dates are same): inst1, inst3, instX, instY, instZ
+    const activeColumn = mockKanbanColumn.mock.calls.find(call => call[0].column.id === activeColumnId)[0].column;
+    const defaultOrder = mockChoreInstancesData
+        .filter(c => c.assignedKidId === kidId && !c.isComplete)
+        .sort((a,b) => new Date(a.instanceDate).getTime() - new Date(b.instanceDate).getTime() || a.id.localeCompare(b.id)) // Example default sort
+        .map(c => c.id);
+
+    expect(activeColumn.chores.map((c: ChoreInstance) => c.id)).toEqual(defaultOrder);
+  });
+
 });


### PR DESCRIPTION
Implements functionality to save and reapply custom drag-and-drop order of chores within Kanban board columns.

Key changes:

1.  **ChoresContext (`ChoresContext.tsx`):**
    - Introduced `kanbanChoreOrders` state to store custom orders (keyed by `kidId-columnIdentifier`, value is an array of chore IDs).
    - This state is loaded from and persisted to `localStorage`.
    - Implemented `updateKanbanChoreOrder` function to add, update, or clear custom orders in the context and localStorage.

2.  **Kanban Board (`KidKanbanBoard.tsx`):**
    - `handleDragEnd`: When a chore is reordered within the same column, `updateKanbanChoreOrder` is now called to save the new sequence.
    - Column Rendering Logic: The main `useEffect` that builds columns now applies any persisted custom order if the "My Order / Due Date" sort option is selected. Chores not in the custom order are appended.
    - Sort Interaction: When an explicit sort ("Title", "Reward Amount") is selected from the dropdown, custom orders for the currently visible columns are cleared (by calling `updateKanbanChoreOrder` with an empty array). The "Due Date" sort option label was updated to "My Order / Due Date" for clarity.

3.  **Testing:**
    - I added tests for `ChoresContext` covering initialization of `kanbanChoreOrders` from localStorage and the full functionality of `updateKanbanChoreOrder`.
    - I updated `KidKanbanBoard` tests to verify:
        - Saving of custom order via `handleDragEnd`.
        - Correct application of custom order during rendering. - Proper interaction with explicit sort options (clearing custom orders).

4.  **Documentation:**
    - I updated JSDoc comments in `ChoresContext.tsx` and `KidKanbanBoard.tsx` for new state, functions, and logic.
    - I updated `FEATURE_TRACKING.md` to mark the completion of the "Persist Custom Chore Order" feature.