### PR TITLE
Fix: Add missing closing div tag in KanbanSettingsView

### DIFF
--- a/src/ui/settings_components/KanbanSettingsView.tsx
+++ b/src/ui/settings_components/KanbanSettingsView.tsx
@@ -365,6 +365,7 @@ const KanbanSettingsView: React.FC = () => {
                   </div>
                 ) : null}
               </DragOverlay>
+              </div>
             </DndContext>
           )}
         </div>


### PR DESCRIPTION
Corrects a JSX error "Expected corresponding JSX closing tag for <div>" by adding the missing `</div>` before the closing `</DndContext>` tag in `src/ui/settings_components/KanbanSettingsView.tsx`.

The unclosed div was `div role="list"` which wraps the sortable context and drag overlay components.