### PR TITLE
Fix: Remove incorrect imports from @dnd-kit/core

### DIFF
--- a/src/ui/settings_components/KanbanSettingsView.tsx
+++ b/src/ui/settings_components/KanbanSettingsView.tsx
@@ -15,9 +15,7 @@ import {
   closestCenter,
   DragEndEvent,
   DragStartEvent,
-  DragOverlay,
-  Active,
-  Over
+  DragOverlay
 } from '@dnd-kit/core';
 import {
   SortableContext,


### PR DESCRIPTION
Removes `Active` and `Over` from the named imports from `@dnd-kit/core` in `src/ui/settings_components/KanbanSettingsView.tsx`. These types are not direct exports from the library.

The types for `event.active` and `event.over` (properties of `DragStartEvent` and `DragEndEvent`) are inferred correctly by TypeScript without needing separate imports. This resolves the SyntaxError: "The requested module does not provide an export named 'Active'".