### PR TITLE
Fix: Correct mismatched JSX closing tag for DndKit.DragOverlay

### DIFF
--- a/src/ui/settings_components/KanbanSettingsView.tsx
+++ b/src/ui/settings_components/KanbanSettingsView.tsx
@@ -352,7 +352,7 @@ const KanbanSettingsView: React.FC = () => {
                     {columnsForSelectedKid.find(c => c.id === activeDragId)?.title}
                   </div>
                 ) : null}
-              </DragOverlay>
+              </DndKit.DragOverlay>
               </div>
             </DndContext>
           )}


### PR DESCRIPTION
In `src/ui/settings_components/KanbanSettingsView.tsx`, the closing tag for the `DndKit.DragOverlay` component was `</DragOverlay>`. This mismatched the opening tag `DndKit.DragOverlay>` that was updated when refactoring to namespace imports for `@dnd-kit/core`.

This commit corrects the closing tag to `</DndKit.DragOverlay>`, resolving the JSX parsing error reported by the vite:react-babel plugin.