### PR TITLE
Fix: Correct further mismatched JSX closing tags for DndKit components

### DIFF
--- a/src/ui/settings_components/KanbanSettingsView.tsx
+++ b/src/ui/settings_components/KanbanSettingsView.tsx
@@ -354,7 +354,7 @@ const KanbanSettingsView: React.FC = () => {
                 ) : null}
               </DndKit.DragOverlay>
               </div>
-            </DndContext>
+            </DndKit.DndContext>
           )}
         </div>
       )}


### PR DESCRIPTION
This commit corrects another mismatched JSX closing tag in `src/ui/settings_components/KanbanSettingsView.tsx`.

- The closing tag for `DndKit.DndContext` was `</DndContext>`, which mismatched the opening tag `DndKit.DndContext>`. This has been corrected to `</DndKit.DndContext>`.

This follows a previous fix for `DndKit.DragOverlay` and aims to fully resolve JSX parsing errors introduced during the refactoring to namespace imports for `@dnd-kit/core`.