### PR TITLE
Fix: Import User type as type-only in KanbanSettingsView

### DIFF
--- a/src/ui/settings_components/KanbanSettingsView.tsx
+++ b/src/ui/settings_components/KanbanSettingsView.tsx
@@ -4,7 +4,7 @@
  * Allows creating, reading, updating, deleting, and reordering Kanban columns.
  */
 import React, { useState, useEffect, useMemo } from 'react';
-import { useUserContext, User } from '../../contexts/UserContext'; // Assuming User type is exported from UserContext
+import { useUserContext, type User } from '../../contexts/UserContext'; // Assuming User type is exported from UserContext
 import type { Kid, KanbanColumnConfig } from '../../types';
 import * as DndKit from '@dnd-kit/core';
 import {


### PR DESCRIPTION
Changes the import of the `User` interface from `UserContext.tsx` in `src/ui/settings_components/KanbanSettingsView.tsx` to be a type-only import (`import { type User } from ...`).

This explicitly signals to TypeScript and the build tools (Vite/esbuild) that `User` is purely a type and should be erased during compilation, preventing it from being treated as a runtime value. This aims to resolve the runtime error "Uncaught SyntaxError: The requested module '/src/contexts/UserContext.tsx' does not provide an export named 'User'".