### PR TITLE
feat: Implement Matrix Kanban core features and UI refinements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4988,6 +4988,7 @@
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.3.tgz",
       "integrity": "sha512-E6U2ZFXe3N/t4f5BwUaVCKRLHqUpk1CBWeMh78UT4VaTPH/2dyvH6ALl29JTovEPu9dVKr/K/J4PkXgrMbw4Ww==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.3",

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,10 @@ export interface Kid {
 export interface SubTask {
   id: string;          // Unique ID for the sub-task (e.g., generated on client-side)
   title: string;
+  /**
+   * Default completion state for this subtask when a new chore instance is created.
+   * For an active chore instance, the actual completion is tracked in `ChoreInstance.subtaskCompletions`.
+   */
   isComplete: boolean;
 }
 
@@ -47,15 +51,40 @@ export interface ChoreDefinition {
 }
 
 export interface ChoreInstance {
-  id: string; // Unique ID for this specific instance (e.g., choreDefId + '_' + instanceDate)
+  /** Unique ID for this specific instance (e.g., `choreDefId + '_' + instanceDate`). */
+  id: string;
+  /** The ID of the `ChoreDefinition` this instance is derived from. */
   choreDefinitionId: string;
-  instanceDate: string; // The specific date this instance is due (YYYY-MM-DD)
-  isComplete: boolean; // Overall completion of the instance (might be true if all subtasks done or moved to COMPLETED category)
+  /**
+   * The specific date (YYYY-MM-DD format) for which this chore instance is scheduled or relevant.
+   * This is crucial for positioning on the date axis of the Matrix Kanban.
+   */
+  instanceDate: string;
+  /**
+   * Overall completion status of the chore instance.
+   * This is typically true if `categoryStatus` is "COMPLETED".
+   * It can also be updated if all subtasks are completed, potentially leading to an auto-move to "COMPLETED".
+   */
+  isComplete: boolean;
 
   // New/Modified for Matrix Kanban:
-  categoryStatus: MatrixKanbanCategory; // Replaces/clarifies kanbanColumnId's role
-  subtaskCompletions: Record<string, boolean>; // Tracks completion of subtasks by subtaskId
-  previousSubtaskCompletions?: Record<string, boolean>; // For reverting from COMPLETED status
+  /**
+   * The current category (swimlane) of the chore instance in the Matrix Kanban.
+   * Uses the fixed `MatrixKanbanCategory` type ("TO_DO", "IN_PROGRESS", "COMPLETED").
+   */
+  categoryStatus: MatrixKanbanCategory;
+  /**
+   * Tracks the completion status of individual subtasks for this specific chore instance.
+   * Structure: A record where the key is the `subTaskId` (from `ChoreDefinition.subTasks`)
+   * and the value is a boolean indicating if that subtask is completed for this instance.
+   */
+  subtaskCompletions: Record<string, boolean>;
+  /**
+   * Stores the state of `subtaskCompletions` before the chore instance was moved into the "COMPLETED" category.
+   * This is used to restore subtask states if the chore is moved back to "IN_PROGRESS" or "TO_DO",
+   * allowing users to uncheck previously completed subtasks if needed. Optional.
+   */
+  previousSubtaskCompletions?: Record<string, boolean>;
 
   // Optional: if reward is snapshotted per instance or can vary
   // rewardAmount?: number;

--- a/src/ui/activity_monitoring_components/DetailedTransactionList.tsx
+++ b/src/ui/activity_monitoring_components/DetailedTransactionList.tsx
@@ -27,11 +27,17 @@ const DetailedTransactionList: React.FC<DetailedTransactionListProps> = ({ trans
       ) : (
         <table>
           <thead>
-            <tr><th>Date</th><th>Kid</th><th>Description</th><th>Category</th><th>Amount</th></tr>
+            <tr>
+              <th>Date</th>
+              <th>Kid</th> {/* Re-enable Kid column */}
+              <th>Description</th>
+              <th>Category</th>
+              <th>Amount</th>
+            </tr>
           </thead>
-          <tbody>
+          <tbody>{/* Ensure no whitespace before map */}
             {transactionsToDisplay.map((tx) => (
-              <tr key={tx.id}>
+              <tr key={tx.id}>{/* Ensure no whitespace before td */}
                 <td>{tx.date}</td>
                 <td>{getKidNameForTable(tx.kidId)}</td> {/* Display kid name */}
                 <td>{tx.description}</td>

--- a/src/ui/kanban_components/CategorySwimlaneView.tsx
+++ b/src/ui/kanban_components/CategorySwimlaneView.tsx
@@ -71,7 +71,7 @@ const CategorySwimlaneView: React.FC<CategorySwimlaneViewProps> = ({ date, categ
             })
           ) : (
             <p style={{fontSize: '0.8em', color: '#777', textAlign: 'center', marginTop: '20px' }}>
-              No chores here.
+              No chores in {categoryTitles[category].toLowerCase()} for this date.
             </p>
           )}
         </div>

--- a/src/ui/kanban_components/KidKanbanBoard.test.tsx
+++ b/src/ui/kanban_components/KidKanbanBoard.test.tsx
@@ -1,21 +1,16 @@
 import { vi } from 'vitest';
 
-// Declare mocks at the very top
-// Use vi.hoisted() for mocks that need to be accessed within vi.mock factory functions
-const mockSortableContextFn = vi.hoisted(() => vi.fn(({ children }) => <>{children}</>));
-const mockDragOverlay = vi.hoisted(() => vi.fn(({ children }) => children ? <div data-testid="drag-overlay-content">{children}</div> : null));
-const mockKanbanColumn = vi.hoisted(() => vi.fn(({ column, theme, instances, onChoreClick }) => (
-  <div data-testid={`mock-kanban-column-${column.id}`} aria-label={`${column.title} column`}>
-    <h2>{column.title}</h2>
-    {instances?.map((inst: ChoreInstance & { definition?: ChoreDefinition } ) => (
-      <div key={inst.id} data-testid={`chore-${inst.id}`} onClick={() => onChoreClick?.(inst.id)}>
-        {inst.definition?.title || inst.id} ({inst.isComplete ? 'C' : 'A'})
-      </div>
-    ))}
-  </div>
-)));
+// Declare mocks at the very top (uninitialized)
+let mockKanbanColumn: any;
+let mockSortableContextFn: any;
+let mockDragOverlay: any;
 
-import { render, screen, within as rtlWithin } from '@testing-library/react';
+// Assign mocks after importing vi, before any vi.mock calls
+mockKanbanColumn = vi.fn();
+mockSortableContextFn = vi.fn();
+mockDragOverlay = vi.fn(({ children }) => children ? <div data-testid="drag-overlay-content">{children}</div> : null);
+
+import { render, screen } from '@testing-library/react';
 import { ChoresContext } from '../../contexts/ChoresContext';
 import { UserContext } from '../../contexts/UserContext';
 import KidKanbanBoard from './KidKanbanBoard';
@@ -24,581 +19,735 @@ import '@testing-library/jest-dom';
 import type { Active, Over } from '@dnd-kit/core';
 import type { DragStartEvent, DragEndEvent } from '@dnd-kit/core';
 import userEvent from '@testing-library/user-event';
-import { act } from 'react'; 
-import * as actualDateUtils from '../../utils/dateUtils'; 
-// Import the entire module to access its mocked functions correctly
-import * as dateUtils from '../../utils/dateUtils';
+import { act } from 'react-dom/test-utils';
+import { getTodayDateString, getWeekRange, getMonthRange } from '../../utils/dateUtils';
 
-// Mock dateUtils to control dates
-vi.mock('../../utils/dateUtils', async () => {
-  const actual = await vi.importActual('../../utils/dateUtils') as typeof actualDateUtils;
-  return {
-    // Spread actual implementations first
-    ...actual,
-    // Then override with mocks
-    getTodayDateString: vi.fn(() => '2024-01-01'), 
-    getWeekRange: vi.fn((dateParam?: Date) => actual.getWeekRange(dateParam || new Date('2024-01-01'))),
-    getMonthRange: vi.fn((dateParam?: Date) => actual.getMonthRange(dateParam || new Date('2024-01-01'))),
-  };
-});
-
-
-vi.mock('./KanbanColumn', () => ({ default: mockKanbanColumn }));
-vi.mock('./KanbanCard', () => ({
-    default: vi.fn(({ instance, definition }) => (
-      <div data-testid={`mock-kanban-card-${instance.id}`}>{definition.title}</div>
-    ))
-}));
-
+// src/ui/kanban_components/KidKanbanBoard.test.tsx
+// Move all mock function declarations above imports and vi.mock() calls to avoid hoisting issues
 
 vi.mock('@dnd-kit/core', async (importOriginal) => {
     const actual = await importOriginal() as object;
-    return { ...actual, DndContext: vi.fn((props) => { dndContextProps = props; return <>{props.children}</>; }),
-        useSensor: vi.fn(), useSensors: vi.fn(() => []), DragOverlay: mockDragOverlay };
+    return {
+        ...actual,
+        DndContext: vi.fn((props) => {
+            dndContextProps = props; // Capture props
+            return <>{props.children}</>;
+        }),
+        useSensor: vi.fn(),
+        useSensors: vi.fn(() => []),
+        DragOverlay: mockDragOverlay // Use the spy mock for DragOverlay
+    };
 });
 vi.mock('@dnd-kit/sortable', async (importOriginal) => {
   const actual = await importOriginal() as object;
-  return { ...actual, sortableKeyboardCoordinates: vi.fn(),
-    arrayMove: vi.fn((arr, from, to) => { const newArr = [...arr]; if (from < 0 || from >= newArr.length || to < 0 || to >= newArr.length) return newArr; const [moved] = newArr.splice(from, 1); newArr.splice(to, 0, moved); return newArr; }),
+  return {
+    ...actual,
+    sortableKeyboardCoordinates: vi.fn(),
+    arrayMove: vi.fn((arr, from, to) => {
+      const newArr = [...arr];
+      if (from < 0 || from >= newArr.length || to < 0 || to >= newArr.length) return newArr; // bounds check
+      const [moved] = newArr.splice(from, 1);
+      newArr.splice(to, 0, moved);
+      return newArr;
+    }),
     SortableContext: mockSortableContextFn
   };
 });
 
+// Mock localStorage
 const localStorageMockFactory = () => {
   let store: Record<string, string> = {};
-  return { getItem: vi.fn((key: string) => store[key] || null), setItem: vi.fn((key: string, value: string) => { store[key] = value.toString(); }), clear: vi.fn(() => { store = {}; }), removeItem: vi.fn((key: string) => { delete store[key]; }), getStore: () => store, };
+  return {
+    getItem: vi.fn((key: string) => store[key] || null),
+    setItem: vi.fn((key: string, value: string) => { store[key] = value.toString(); }),
+    clear: vi.fn(() => { store = {}; }),
+    removeItem: vi.fn((key: string) => { delete store[key]; }),
+    getStore: () => store,
+  };
 };
 let localStorageMock = localStorageMockFactory();
+
+// Mock ChoresContext
+const mockGenerateInstancesForPeriod = vi.fn();
+const mockToggleChoreInstanceComplete = vi.fn();
+const mockUpdateKanbanChoreOrder = vi.fn();
+const mockUpdateChoreInstanceColumn = vi.fn(); // Mock for updating instance's column
 
 const mockChoreDefinitions: ChoreDefinition[] = [
   { id: 'def1', title: 'Walk the Dog', assignedKidId: 'kid1', rewardAmount: 5, subTasks:[], tags:[], recurrenceType: null, createdAt: '2023-01-01', updatedAt: '2023-01-01', hour:10, minute:0, timeOfDay:'AM' },
   { id: 'def2', title: 'Clean Room', assignedKidId: 'kid1', rewardAmount: 10, subTasks:[], tags:[], recurrenceType: null, createdAt: '2023-01-01', updatedAt: '2023-01-01', hour:10, minute:0, timeOfDay:'AM' },
   { id: 'def3', title: 'Do Homework', assignedKidId: 'kid1', rewardAmount: 0, subTasks:[], tags:[], recurrenceType: null, createdAt: '2023-01-01', updatedAt: '2023-01-01', hour:10, minute:0, timeOfDay:'AM' },
   { id: 'def4', title: 'Wash Dishes', assignedKidId: 'kid2', rewardAmount: 3, subTasks:[], tags:[], recurrenceType: null, createdAt: '2023-01-01', updatedAt: '2023-01-01', hour:10, minute:0, timeOfDay:'AM' },
+  // For custom order testing, ensure these are assigned to kid1
   { id: 'def5', title: 'Chore X (for custom order)', assignedKidId: 'kid1', rewardAmount: 1, subTasks:[], tags:[], recurrenceType: null, createdAt: '2023-01-01', updatedAt: '2023-01-01', hour:10, minute:0, timeOfDay:'AM' },
   { id: 'def6', title: 'Chore Y (for custom order)', assignedKidId: 'kid1', rewardAmount: 1, subTasks:[], tags:[], recurrenceType: null, createdAt: '2023-01-01', updatedAt: '2023-01-01', hour:10, minute:0, timeOfDay:'AM' },
   { id: 'def7', title: 'Chore Z (for custom order)', assignedKidId: 'kid1', rewardAmount: 1, subTasks:[], tags:[], recurrenceType: null, createdAt: '2023-01-01', updatedAt: '2023-01-01', hour:10, minute:0, timeOfDay:'AM' },
 ];
 
-let mockChoreInstancesData: ChoreInstance[]; 
-const today_fixed_for_reset = '2024-01-01'; 
+const today = getTodayDateString();
+let mockChoreInstancesData: ChoreInstance[];
 
 const resetMockChoreInstances = () => {
     mockChoreInstancesData = [
-        { id: 'inst1', choreDefinitionId: 'def1', instanceDate: today_fixed_for_reset, isComplete: false, assignedKidId: 'kid1' },
-        { id: 'inst2', choreDefinitionId: 'def2', instanceDate: today_fixed_for_reset, isComplete: true, assignedKidId: 'kid1' },
-        { id: 'inst3', choreDefinitionId: 'def3', instanceDate: today_fixed_for_reset, isComplete: false, assignedKidId: 'kid1' },
-        { id: 'inst4', choreDefinitionId: 'def4', instanceDate: today_fixed_for_reset, isComplete: false, assignedKidId: 'kid2' },
-        { id: 'instX', choreDefinitionId: 'def5', instanceDate: today_fixed_for_reset, isComplete: false, assignedKidId: 'kid1' },
-        { id: 'instY', choreDefinitionId: 'def6', instanceDate: today_fixed_for_reset, isComplete: false, assignedKidId: 'kid1' },
-        { id: 'instZ', choreDefinitionId: 'def7', instanceDate: today_fixed_for_reset, isComplete: false, assignedKidId: 'kid1' },
+        { id: 'inst1', choreDefinitionId: 'def1', instanceDate: today, isComplete: false },
+        { id: 'inst2', choreDefinitionId: 'def2', instanceDate: today, isComplete: true },
+        { id: 'inst3', choreDefinitionId: 'def3', instanceDate: today, isComplete: false },
+        { id: 'inst4', choreDefinitionId: 'def4', instanceDate: today, isComplete: false },
+        // For custom order testing
+        { id: 'instX', choreDefinitionId: 'def5', instanceDate: today, isComplete: false },
+        { id: 'instY', choreDefinitionId: 'def6', instanceDate: today, isComplete: false },
+        { id: 'instZ', choreDefinitionId: 'def7', instanceDate: today, isComplete: false },
     ];
 };
 
 let mockKanbanChoreOrdersData: Record<string, string[]> = {};
-const resetMockKanbanChoreOrders = () => { mockKanbanChoreOrdersData = {}; };
 
-let latestContextMocks: { generateInstancesForPeriod: ReturnType<typeof vi.fn>; toggleChoreInstanceComplete: ReturnType<typeof vi.fn>; updateKanbanChoreOrder: ReturnType<typeof vi.fn>; updateChoreInstanceColumn: ReturnType<typeof vi.fn>; } | null = null;
+const resetMockKanbanChoreOrders = () => {
+    mockKanbanChoreOrdersData = {};
+}
 
-const mockContextValueFactory = (customOrders: Record<string, string[]> = {}) => {
-    const newMocks = {
-        generateInstancesForPeriod: vi.fn(), toggleChoreInstanceComplete: vi.fn(), updateKanbanChoreOrder: vi.fn(), updateChoreInstanceColumn: vi.fn(),
-        addChoreDefinition: vi.fn(), updateChoreDefinition: vi.fn(), deleteChoreDefinition: vi.fn(), addChoreInstance: vi.fn(), updateChoreInstance: vi.fn(), deleteChoreInstance: vi.fn(), toggleSubTaskComplete: vi.fn(),
-    };
-    latestContextMocks = newMocks; 
-    const currentDefinitions = JSON.parse(JSON.stringify(mockChoreDefinitions)); 
-    const currentInstances = JSON.parse(JSON.stringify(mockChoreInstancesData));
-    const contextObject = {
-        choreDefinitions: currentDefinitions, choreInstances: currentInstances, kanbanChoreOrders: JSON.parse(JSON.stringify(customOrders)), ...newMocks, 
-        getDefinitionById: (id: string) => contextObject.choreDefinitions.find(d => d.id === id),
-        getInstancesForDefinition: (defId: string) => contextObject.choreInstances.filter(i => i.choreDefinitionId === defId),
-        loadingDefinitions: false, loadingInstances: false, errorDefinitions: null, errorInstances: null,
-        getChoreDefinitionsForKid: (kidId: string) => contextObject.choreDefinitions.filter(def => def.assignedKidId === kidId),
-    };
-    return contextObject as any;
-};
+const mockContextValueFactory = (customOrders: Record<string, string[]> = {}) => ({
+  choreDefinitions: mockChoreDefinitions,
+  get choreInstances() { return mockChoreInstancesData; },
+  kanbanChoreOrders: customOrders, // Use passed customOrders or default
+  generateInstancesForPeriod: mockGenerateInstancesForPeriod,
+  toggleChoreInstanceComplete: mockToggleChoreInstanceComplete,
+  updateKanbanChoreOrder: mockUpdateKanbanChoreOrder,
+  getDefinitionById: (id: string) => mockChoreDefinitions.find(d => d.id === id),
+  getInstancesForDefinition: (defId: string) => mockChoreInstancesData.filter(i => i.choreDefinitionId === defId),
+  updateChoreInstanceColumn: mockUpdateChoreInstanceColumn, // Add to factory
+  loadingDefinitions: false, loadingInstances: false, errorDefinitions: null, errorInstances: null,
+  addChoreDefinition: vi.fn(), updateChoreDefinition: vi.fn(), deleteChoreDefinition: vi.fn(),
+  addChoreInstance: vi.fn(), updateChoreInstance: vi.fn(), deleteChoreInstance: vi.fn(),
+  toggleSubTaskComplete: vi.fn(),
+  getChoreDefinitionsForKid: (kidId: string) => mockChoreDefinitions.filter(def => def.assignedKidId === kidId),
+} as any);
 
+// Mock UserContext for getKanbanColumnConfigs
 const mockGetKanbanColumnConfigs = vi.fn();
 const mockUserContextValue = {
-    user: { id: 'user1', username: 'Test User', email: '', kids: [{id: 'kid1', name: 'Test Kid', kanbanColumnConfigs: []},{id: 'kid2', name: 'Test Kid2', kanbanColumnConfigs: []}]},
-    loading: false, error: null, getKanbanColumnConfigs: mockGetKanbanColumnConfigs,
+    user: { id: 'user1', username: 'Test User', email: '', kids: [{id: 'kid1', name: 'Test Kid', kanbanColumnConfigs: []}]},
+    loading: false,
+    error: null,
+    getKanbanColumnConfigs: mockGetKanbanColumnConfigs,
+    // Add other UserContext functions as vi.fn() if needed by KidKanbanBoard directly or indirectly
     login: vi.fn(), logout: vi.fn(), updateUser: vi.fn(), addKid: vi.fn(), updateKid: vi.fn(), deleteKid: vi.fn(),
     addKanbanColumnConfig: vi.fn(), updateKanbanColumnConfig: vi.fn(), deleteKanbanColumnConfig: vi.fn(), reorderKanbanColumnConfigs: vi.fn(),
 };
+// Import UserContext to use its Provider
+import { getTodayDateString } from '../../utils/dateUtils';
 
+// dndContextProps is used to capture DndContext props in mocks
 let dndContextProps: any = {};
 
-const renderKidKanbanBoard = ( kidId = 'kid1', choresContextVal?: any, userContextVal?: any ) => {
-  const finalChoresContextVal = choresContextVal || mockContextValueFactory(mockKanbanChoreOrdersData);
-  const finalUserContextVal = userContextVal || { ...mockUserContextValue, getKanbanColumnConfigs: mockGetKanbanColumnConfigs };
-  const instancesToUse = (finalChoresContextVal && finalChoresContextVal.choreInstances && finalChoresContextVal.choreInstances.length > 0)
-    ? finalChoresContextVal.choreInstances : [...mockChoreInstancesData];
-  const freshChoresContext = {...finalChoresContextVal, choreInstances: instancesToUse, kanbanChoreOrders: {...finalChoresContextVal.kanbanChoreOrders}};
-  const kidExists = finalUserContextVal.user?.kids.find((k:any) => k.id === kidId);
-  let resolvedUserContextVal = finalUserContextVal;
-  if (finalUserContextVal.user && !kidExists) {
-    resolvedUserContextVal = { ...finalUserContextVal, user: { ...finalUserContextVal.user, kids: [...finalUserContextVal.user.kids, { id: kidId, name: `Test Kid ${kidId}`, kanbanColumnConfigs: [] }]}};
+const renderKidKanbanBoard = (
+    kidId = 'kid1',
+    choresContextVal = mockContextValueFactory(mockKanbanChoreOrdersData),
+    userContextVal = { ...mockUserContextValue, getKanbanColumnConfigs: mockGetKanbanColumnConfigs }
+) => {
+  const freshChoresContext = {...choresContextVal, choreInstances: [...mockChoreInstancesData], kanbanChoreOrders: {...choresContextVal.kanbanChoreOrders}};
+
+  // Ensure the specific kidId being tested exists in the mock user's kids array
+  const kidExists = userContextVal.user?.kids.find(k => k.id === kidId);
+  let finalUserContextVal = userContextVal;
+  if (userContextVal.user && !kidExists) {
+    finalUserContextVal = {
+        ...userContextVal,
+        user: {
+            ...userContextVal.user,
+            kids: [...userContextVal.user.kids, { id: kidId, name: `Test Kid ${kidId}`, kanbanColumnConfigs: [] }]
+        }
+    }
   }
-  return render( <UserContext.Provider value={resolvedUserContextVal}><ChoresContext.Provider value={freshChoresContext}><KidKanbanBoard kidId={kidId} /></ChoresContext.Provider></UserContext.Provider> );
+
+
+  return render(
+    <UserContext.Provider value={finalUserContextVal}>
+      <ChoresContext.Provider value={freshChoresContext}>
+        <KidKanbanBoard kidId={kidId} />
+      </ChoresContext.Provider>
+    </UserContext.Provider>
+  );
 };
 
-const createMockActive = (id: string, containerId: string, index = 0, items: string[] = []): Active => ({ id, data: { current: { sortable: { containerId, index, items } } }, rect: { current: { initial: null, translated: null } }, });
-const createMockOver = (id: string, containerId?: string, index = 0, items: string[] = []): Over => ({ id, rect: { width: 0, height: 0, top: 0, left: 0, right: 0, bottom: 0 }, data: { current: containerId ? { sortable: { containerId, index, items } } : {} }, disabled: false, });
+// Helper for D&D event objects
+const createMockActive = (id: string, containerId: string, index = 0, items: string[] = []): Active => ({
+  id,
+  data: { current: { sortable: { containerId, index, items } } },
+  rect: { current: { initial: null, translated: null } },
+});
+
+const createMockOver = (id: string, containerId?: string, index = 0, items: string[] = []): Over => ({
+  id,
+  rect: { width: 0, height: 0, top: 0, left: 0, right: 0, bottom: 0 },
+  data: { current: containerId ? { sortable: { containerId, index, items } } : {} },
+  disabled: false,
+});
 
 describe('KidKanbanBoard - Rendering and Basic Interactions (Part 1)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    // Access mocks through the imported module namespace
-    (dateUtils.getTodayDateString as vi.Mock).mockReturnValue('2024-01-01');
-    (dateUtils.getWeekRange as vi.Mock).mockImplementation((date = new Date('2024-01-01')) => actualDateUtils.getWeekRange(date));
-    (dateUtils.getMonthRange as vi.Mock).mockImplementation((date = new Date('2024-01-01')) => actualDateUtils.getMonthRange(date));
-
-    mockGetKanbanColumnConfigs.mockReturnValue([]); 
-    latestContextMocks = null; 
     localStorageMock = localStorageMockFactory();
-    Object.defineProperty(window, 'localStorage', { value: localStorageMock, writable: true, configurable: true });
-    localStorageMock.getItem.mockImplementation((key: string) => (key === 'kanban_columnTheme') ? 'default' : null);
-    resetMockChoreInstances(); 
-    dndContextProps = {}; 
+    Object.defineProperty(window, 'localStorage', {
+      value: localStorageMock,
+      writable: true,
+      configurable: true,
+    });
+    localStorageMock.getItem.mockImplementation((key: string) => {
+        if (key === 'kanban_columnTheme') return 'default';
+        return null;
+    });
+    resetMockChoreInstances(); // Reset instances for each test in this block too
+    dndContextProps = {}; // Reset captured DndContext props
   });
 
   test('renders initial controls and calls generateInstancesForPeriod for today', () => {
     renderKidKanbanBoard();
     expect(screen.getByRole('button', { name: 'Daily' })).toBeDisabled();
-    expect(latestContextMocks?.generateInstancesForPeriod).toHaveBeenCalledWith('2024-01-01', '2024-01-01', undefined);
+    expect(screen.getByRole('button', { name: 'Weekly' })).toBeEnabled();
+    expect(screen.getByRole('button', { name: 'Monthly' })).toBeEnabled();
+
+    expect(screen.getByLabelText(/Filter by Reward:/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Sort by:/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Column Theme:/i)).toBeInTheDocument();
+
+    const todayStr = getTodayDateString();
+    expect(mockGenerateInstancesForPeriod).toHaveBeenCalledWith(todayStr, todayStr);
   });
 
   test('renders columns and chores correctly for default (daily) period', () => {
-    resetMockChoreInstances(); 
-    const dailyActiveCol_rcTest: KanbanColumnConfig = { id: 'daily_active', title: 'Today - Active', order: 0, kidId: 'kid1', createdAt: '', updatedAt: '' };
-    const dailyCompletedCol_rcTest: KanbanColumnConfig = { id: 'daily_completed', title: 'Today - Completed', order: 1, kidId: 'kid1', createdAt: '', updatedAt: '' };
-    const customUserContext_rcTest = { ...mockUserContextValue, getKanbanColumnConfigs: vi.fn(() => [dailyActiveCol_rcTest, dailyCompletedCol_rcTest]) };
-    renderKidKanbanBoard('kid1', mockContextValueFactory(), customUserContext_rcTest);
+    renderKidKanbanBoard('kid1');
     expect(screen.getByRole('heading', { name: 'Today - Active' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Today - Completed' })).toBeInTheDocument();
+
+    // Verify ARIA attributes for the columns container
+    expect(screen.getByLabelText('Kanban board columns')).toHaveAttribute('role', 'list');
+
     const activeColumn = screen.getByTestId('mock-kanban-column-daily_active');
-    expect(rtlWithin(activeColumn).getByTestId('chore-inst1')).toHaveTextContent('inst1 (A)');
-    expect(rtlWithin(activeColumn).getByTestId('chore-inst3')).toHaveTextContent('inst3 (A)');
+    expect(within(activeColumn).getByTestId('chore-inst1')).toHaveTextContent('inst1 (A)');
+    expect(within(activeColumn).getByTestId('chore-inst3')).toHaveTextContent('inst3 (A)');
+    expect(within(activeColumn).queryByTestId('chore-inst2')).not.toBeInTheDocument();
+    expect(within(activeColumn).queryByTestId('chore-inst4')).not.toBeInTheDocument();
+
+    const completedColumn = screen.getByTestId('mock-kanban-column-daily_completed');
+    expect(within(completedColumn).getByTestId('chore-inst2')).toHaveTextContent('inst2 (C)');
+    expect(within(completedColumn).queryByTestId('chore-inst1')).not.toBeInTheDocument();
   });
 
   test('period selection calls generateInstancesForPeriod and updates titles', async () => {
-    const user_psTest = userEvent.setup();
-    (dateUtils.getTodayDateString as vi.Mock).mockReturnValue('2024-01-01');
-    resetMockChoreInstances();
+    const user = userEvent.setup();
+    renderKidKanbanBoard();
 
-    const initialDailyActiveCol_psTest: KanbanColumnConfig = { id: 'daily_active', title: 'Today - Active', order: 0, kidId: 'kid1', createdAt: '', updatedAt: '' };
-    const initialDailyCompletedCol_psTest: KanbanColumnConfig = { id: 'daily_completed', title: 'Today - Completed', order: 1, kidId: 'kid1', createdAt: '', updatedAt: '' };
-    const initialMockUserGetColumns_psTest = vi.fn().mockReturnValue([initialDailyActiveCol_psTest, initialDailyCompletedCol_psTest]);
-    const initialCustomUserContext_psTest = { ...mockUserContextValue, getKanbanColumnConfigs: initialMockUserGetColumns_psTest };
-    
-    let r_psTest = renderKidKanbanBoard('kid1', mockContextValueFactory(), initialCustomUserContext_psTest);
-    expect(r_psTest.getByRole('heading', { name: 'Today - Active' })).toBeInTheDocument();
-    expect(latestContextMocks?.generateInstancesForPeriod).toHaveBeenCalledWith('2024-01-01', '2024-01-01', initialDailyActiveCol_psTest.id);
+    await user.click(screen.getByRole('button', { name: 'Weekly' }));
+    const weekRange = getWeekRange(new Date());
+    expect(mockGenerateInstancesForPeriod).toHaveBeenCalledWith(
+      weekRange.start.toISOString().split('T')[0],
+      weekRange.end.toISOString().split('T')[0]
+    );
+    expect(screen.getByRole('heading', { name: 'This Week - Active' })).toBeInTheDocument();
 
-    // Test Weekly
-    const weeklyActiveCol_psTest: KanbanColumnConfig = { id: 'weekly_active', title: 'This Week - Active', order: 0, kidId: 'kid1', createdAt: '', updatedAt: '' };
-    const weeklyUserContext_psTest = { ...mockUserContextValue, getKanbanColumnConfigs: vi.fn(() => [weeklyActiveCol_psTest]) };
-    r_psTest.unmount(); 
-    r_psTest = renderKidKanbanBoard('kid1', mockContextValueFactory(), weeklyUserContext_psTest); 
-    
-    (dateUtils.getWeekRange as vi.Mock).mockReturnValueOnce({ start: new Date('2024-01-01'), end: new Date('2024-01-07')});
-    await user_psTest.click(r_psTest.getByRole('button', { name: 'Weekly' })); 
-    expect(latestContextMocks?.generateInstancesForPeriod).toHaveBeenCalledWith( 
-      '2024-01-01', 
-      '2024-01-07', 
-      weeklyActiveCol_psTest.id
+    await user.click(screen.getByRole('button', { name: 'Monthly' }));
+    const monthRange = getMonthRange(new Date());
+    expect(mockGenerateInstancesForPeriod).toHaveBeenCalledWith(
+      monthRange.start.toISOString().split('T')[0],
+      monthRange.end.toISOString().split('T')[0]
     );
-    expect(r_psTest.getByRole('heading', { name: 'This Week - Active' })).toBeInTheDocument();
-    
-    // Test Monthly
-    const monthlyActiveCol_psTest: KanbanColumnConfig = { id: 'monthly_active', title: 'This Month - Active', order: 0, kidId: 'kid1', createdAt: '', updatedAt: '' };
-    const monthlyUserContext_psTest = { ...mockUserContextValue, getKanbanColumnConfigs: vi.fn(() => [monthlyActiveCol_psTest]) };
-    r_psTest.unmount(); 
-    r_psTest = renderKidKanbanBoard('kid1', mockContextValueFactory(), monthlyUserContext_psTest); 
-    
-    (dateUtils.getMonthRange as vi.Mock).mockReturnValueOnce({ start: new Date('2024-01-01'), end: new Date('2024-01-31')});
-    await user_psTest.click(r_psTest.getByRole('button', { name: 'Monthly' })); 
-    expect(latestContextMocks?.generateInstancesForPeriod).toHaveBeenCalledWith(
-      '2024-01-01', 
-      '2024-01-31', 
-      monthlyActiveCol_psTest.id
-    );
-    expect(r_psTest.getByRole('heading', { name: 'This Month - Active' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'This Month - Active' })).toBeInTheDocument();
   });
 
   test('reward filter updates displayed chores', async () => {
-    const user_rfTest = userEvent.setup();
-    resetMockChoreInstances(); 
-    const dailyActiveCol_rfTest: KanbanColumnConfig = { id: 'daily_active', title: 'Today - Active', order: 0, kidId: 'kid1', createdAt: '', updatedAt: '' };
-    const dailyCompletedCol_rfTest: KanbanColumnConfig = { id: 'daily_completed', title: 'Today - Completed', order: 1, kidId: 'kid1', createdAt: '', updatedAt: '' };
-    const customUserContext_rfTest = { ...mockUserContextValue, getKanbanColumnConfigs: vi.fn(() => [dailyActiveCol_rfTest, dailyCompletedCol_rfTest]) };
-    renderKidKanbanBoard('kid1', mockContextValueFactory(), customUserContext_rfTest);
+    const user = userEvent.setup();
+    renderKidKanbanBoard('kid1');
 
-    let activeColumn_rfTest = screen.getByTestId('mock-kanban-column-daily_active');
-    expect(rtlWithin(activeColumn_rfTest).getByTestId('chore-inst1')).toBeInTheDocument();
-    const rewardFilterSelect_rfTest = screen.getByLabelText(/Filter by Reward:/i);
-    await user_rfTest.selectOptions(rewardFilterSelect_rfTest, 'has_reward');
-    activeColumn_rfTest = screen.getByTestId('mock-kanban-column-daily_active'); 
-    expect(rtlWithin(activeColumn_rfTest).getByTestId('chore-inst1')).toBeInTheDocument();
-    await user_rfTest.selectOptions(rewardFilterSelect_rfTest, 'no_reward');
-    activeColumn_rfTest = screen.getByTestId('mock-kanban-column-daily_active'); 
-    expect(rtlWithin(activeColumn_rfTest).getByTestId('chore-inst3')).toBeInTheDocument();
+    let activeColumn = screen.getByTestId('mock-kanban-column-daily_active');
+    expect(within(activeColumn).getByTestId('chore-inst1')).toBeInTheDocument();
+    expect(within(activeColumn).getByTestId('chore-inst3')).toBeInTheDocument();
+
+    const rewardFilterSelect = screen.getByLabelText(/Filter by Reward:/i);
+    await user.selectOptions(rewardFilterSelect, 'has_reward');
+
+    activeColumn = screen.getByTestId('mock-kanban-column-daily_active'); // Re-query after update
+    expect(within(activeColumn).getByTestId('chore-inst1')).toBeInTheDocument();
+    expect(within(activeColumn).queryByTestId('chore-inst3')).not.toBeInTheDocument();
+
+    await user.selectOptions(rewardFilterSelect, 'no_reward');
+    activeColumn = screen.getByTestId('mock-kanban-column-daily_active'); // Re-query
+    expect(within(activeColumn).queryByTestId('chore-inst1')).not.toBeInTheDocument();
+    expect(within(activeColumn).getByTestId('chore-inst3')).toBeInTheDocument();
   });
 
   test('sort option changes order of chores', async () => {
-    const user_sortTest = userEvent.setup();
-    const today_sortTest = (dateUtils.getTodayDateString as vi.Mock)();
-    const sortTestInstances_sortTest: ChoreInstance[] = [
-      { id: 'c_inst', choreDefinitionId: 'def3', instanceDate: today_sortTest, isComplete: false, assignedKidId: 'kid1' }, 
-      { id: 'a_inst', choreDefinitionId: 'def1', instanceDate: today_sortTest, isComplete: false, assignedKidId: 'kid1' }, 
-      { id: 'b_inst', choreDefinitionId: 'def2', instanceDate: today_sortTest, isComplete: false, assignedKidId: 'kid1' }, 
+    const user = userEvent.setup();
+    const sortTestInstances: ChoreInstance[] = [
+      { id: 'c_inst', choreDefinitionId: 'def3', instanceDate: today, isComplete: false }, // Reward 0
+      { id: 'a_inst', choreDefinitionId: 'def1', instanceDate: today, isComplete: false }, // Reward 5
+      { id: 'b_inst', choreDefinitionId: 'def2', instanceDate: today, isComplete: false }, // Reward 10
     ];
-    const dailyActiveCol_sortTest: KanbanColumnConfig = { id: 'daily_active', title: 'Today - Active', order: 0, kidId: 'kid1', createdAt: '', updatedAt: '' };
-    const customUserContext_sortTest = { ...mockUserContextValue, getKanbanColumnConfigs: vi.fn(() => [dailyActiveCol_sortTest, {id: 'comp', title:'C', kidId:'kid1', order:1, createdAt:'', updatedAt:''}]) };
-    const customChoresContext_sortTest = mockContextValueFactory(); 
-    customChoresContext_sortTest.choreInstances = [...sortTestInstances_sortTest]; 
-    const sortInstanceDefIds_sortTest = sortTestInstances_sortTest.map(si => si.choreDefinitionId);
-    customChoresContext_sortTest.choreDefinitions = mockChoreDefinitions.filter(def => sortInstanceDefIds_sortTest.includes(def.id));
-    renderKidKanbanBoard('kid1', customChoresContext_sortTest, customUserContext_sortTest);
-    const sortBySelect_sortTest = screen.getByLabelText(/Sort by:/i);
-    const sortDirectionButton_sortTest = screen.getByRole('button', { name: /A-Z \/ Old-New ↑/i });
-    await user_sortTest.selectOptions(sortBySelect_sortTest, 'title');
-    let activeColumnCalls_sortTest = mockKanbanColumn.mock.calls.filter(call => call[0].column.id === 'daily_active');
-    let lastActiveColumnCall_sortTest = activeColumnCalls_sortTest[activeColumnCalls_sortTest.length - 1];
-    let activeColumnChores_sortTest = lastActiveColumnCall_sortTest?.[0]?.column.chores;
-    expect(activeColumnChores_sortTest?.map((c:ChoreInstance) => c.id)).toEqual(['b_inst', 'c_inst', 'a_inst']);
-    await user_sortTest.click(sortDirectionButton_sortTest); 
-    activeColumnCalls_sortTest = mockKanbanColumn.mock.calls.filter(call => call[0].column.id === 'daily_active');
-    lastActiveColumnCall_sortTest = activeColumnCalls_sortTest[activeColumnCalls_sortTest.length - 1];
-    activeColumnChores_sortTest = lastActiveColumnCall_sortTest?.[0]?.column.chores;
-    expect(activeColumnChores_sortTest?.map((c:ChoreInstance) => c.id)).toEqual(['a_inst', 'c_inst', 'b_inst']);
+    // Definitions need to match IDs used in sortTestInstances
+    const customContext = { ...mockContextValueFactory, choreInstances: [...sortTestInstances], choreDefinitions: [...mockChoreDefinitions] };
+    renderKidKanbanBoard('kid1', customContext);
+
+    const sortBySelect = screen.getByLabelText(/Sort by:/i);
+    const sortDirectionButton = screen.getByRole('button', { name: /A-Z \/ Old-New ↓/i });
+
+    await user.selectOptions(sortBySelect, 'title');
+    let activeColumnChores = mockKanbanColumn.mock.calls.find(call => call[0].column.id === 'daily_active')?.[0]?.column.chores;
+    // Titles: Walk the Dog (def1, a_inst), Clean Room (def2, b_inst), Do Homework (def3, c_inst)
+    // Expected order for title ASC: Clean Room, Do Homework, Walk the Dog
+    expect(activeColumnChores?.map((c:ChoreInstance) => c.id)).toEqual(['b_inst', 'c_inst', 'a_inst']);
+
+    await user.click(sortDirectionButton);
+    activeColumnChores = mockKanbanColumn.mock.calls.find(call => call[0].column.id === 'daily_active')?.[0]?.column.chores;
+    expect(activeColumnChores?.map((c:ChoreInstance) => c.id)).toEqual(['a_inst', 'c_inst', 'b_inst']);
+
+    await user.selectOptions(sortBySelect, 'rewardAmount'); // Default to DESC for reward
+    activeColumnChores = mockKanbanColumn.mock.calls.find(call => call[0].column.id === 'daily_active')?.[0]?.column.chores;
+    // Rewards: a_inst (5), b_inst (10), c_inst (0). DESC: b_inst, a_inst, c_inst
+    expect(activeColumnChores?.map((c:ChoreInstance) => c.id)).toEqual(['b_inst', 'a_inst', 'c_inst']);
+
+    await user.click(screen.getByRole('button', { name: /High to Low ↓/i })); // Change to ASC
+    activeColumnChores = mockKanbanColumn.mock.calls.find(call => call[0].column.id === 'daily_active')?.[0]?.column.chores;
+    expect(activeColumnChores?.map((c:ChoreInstance) => c.id)).toEqual(['c_inst', 'a_inst', 'b_inst']);
   });
 
   test('theme selection updates localStorage and column theme prop', async () => {
-    const user_themeTest = userEvent.setup();
-    const dailyActiveCol_themeTest: KanbanColumnConfig = { id: 'daily_active', title: 'Today - Active', order: 0, kidId: 'kid1', createdAt: '', updatedAt: '' };
-    const userContextWithCols_themeTest = { ...mockUserContextValue, getKanbanColumnConfigs: vi.fn(() => [dailyActiveCol_themeTest, {id:'comp', title:'C', kidId:'kid1', order:1, createdAt:'', updatedAt:''}]) };
-    renderKidKanbanBoard('kid1', mockContextValueFactory(), userContextWithCols_themeTest);
-    const themeSelect_themeTest = screen.getByLabelText(/Column Theme:/i);
-    await user_themeTest.selectOptions(themeSelect_themeTest, 'pastel');
+    const user = userEvent.setup();
+    renderKidKanbanBoard();
+
+    const themeSelect = screen.getByLabelText(/Column Theme:/i);
+    await user.selectOptions(themeSelect, 'pastel');
+
     expect(localStorageMock.setItem).toHaveBeenCalledWith('kanban_columnTheme', 'pastel');
-    let pastelCall_themeTest = mockKanbanColumn.mock.calls.find(call => call[0].column.id === 'daily_active' && call[0].theme === 'pastel');
-    expect(pastelCall_themeTest).toBeDefined();
-    await user_themeTest.selectOptions(themeSelect_themeTest, 'ocean');
+    const lastColumnCallArgs = mockKanbanColumn.mock.calls[mockKanbanColumn.mock.calls.length -1][0];
+    expect(lastColumnCallArgs.theme).toBe('pastel');
+
+    await user.selectOptions(themeSelect, 'ocean');
     expect(localStorageMock.setItem).toHaveBeenCalledWith('kanban_columnTheme', 'ocean');
-    let oceanCall_themeTest = mockKanbanColumn.mock.calls.find(call => call[0].column.id === 'daily_active' && call[0].theme === 'ocean');
-    expect(oceanCall_themeTest).toBeDefined();
+    const latestColumnCallArgs = mockKanbanColumn.mock.calls[mockKanbanColumn.mock.calls.length -1][0];
+    expect(latestColumnCallArgs.theme).toBe('ocean');
   });
 });
+
+
+
+// Helper for queryByTestId within a container
+import { queries, getQueriesForElement } from '@testing-library/dom';
+function within(element: HTMLElement) {
+  return getQueriesForElement(element, queries);
+}
 
 describe('KidKanbanBoard - Drag and Drop Event Handling (Part 2)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockGetKanbanColumnConfigs.mockReturnValue([]); 
-    latestContextMocks = null; 
-    resetMockChoreInstances(); 
-    localStorageMock = localStorageMockFactory();
-    Object.defineProperty(window, 'localStorage', { value: localStorageMock, writable: true, configurable: true, });
-    localStorageMock.getItem.mockImplementation((key: string) => (key === 'kanban_columnTheme') ? 'default' : (key === 'kanbanChoreOrders' ? JSON.stringify(mockKanbanChoreOrdersData) : null));
-    resetMockKanbanChoreOrders(); 
-    dndContextProps = {}; 
+    localStorageMock = localStorageMockFactory(); // Reset localStorage for each test
+    Object.defineProperty(window, 'localStorage', {
+      value: localStorageMock,
+      writable: true,
+      configurable: true,
+    });
+    resetMockChoreInstances();
+    resetMockKanbanChoreOrders(); // Reset custom orders for each test
+    dndContextProps = {};
+
+    localStorageMock.getItem.mockImplementation((key: string) => {
+        if (key === 'kanban_columnTheme') return 'default';
+        if (key === 'kanbanChoreOrders') return JSON.stringify(mockKanbanChoreOrdersData); // Use mutable mock data
+        return null;
+    });
   });
 
   test('handleDragStart sets activeDragItem and shows DragOverlay', () => {
-    const dailyActiveCol_dragStart: KanbanColumnConfig = { id: 'daily_active', title: 'Today - Active', order: 0, kidId: 'kid1', createdAt: '', updatedAt: '' };
-    const userContext_dragStart = { ...mockUserContextValue, getKanbanColumnConfigs: vi.fn(() => [dailyActiveCol_dragStart]) };
-    renderKidKanbanBoard('kid1', mockContextValueFactory(), userContext_dragStart);
-    const dragStartEvent: DragStartEvent = { active: createMockActive('inst1', 'daily_active'), activatorEvent: {} as any };
-    act(() => { dndContextProps.onDragStart(dragStartEvent); });
+    renderKidKanbanBoard('kid1');
+    const dragStartEvent: DragStartEvent = {
+      active: createMockActive('inst1', 'daily_active'),
+      activatorEvent: {} as any,
+    };
+    act(() => {
+      dndContextProps.onDragStart(dragStartEvent);
+    });
+    // Verify DragOverlay is called with children (meaning activeDragItem is set)
     expect(mockDragOverlay).toHaveBeenCalled();
     expect(screen.getByTestId('drag-overlay-content')).toBeInTheDocument();
+    // Check if the correct card is in the overlay (mockKanbanCard renders title)
+    const definitionForInst1 = mockChoreDefinitions.find(d => d.id === 'def1');
+    expect(screen.getByTestId('drag-overlay-content')).toHaveTextContent(definitionForInst1!.title);
   });
 
   test('handleDragEnd clears activeDragItem and DragOverlay', () => {
-    const dailyActiveCol_dragEndClear: KanbanColumnConfig = { id: 'daily_active', title: 'Today - Active', order: 0, kidId: 'kid1', createdAt: '', updatedAt: '' };
-    const userContext_dragEndClear = { ...mockUserContextValue, getKanbanColumnConfigs: vi.fn(() => [dailyActiveCol_dragEndClear]) };
-    renderKidKanbanBoard('kid1', mockContextValueFactory(), userContext_dragEndClear);
+    renderKidKanbanBoard('kid1');
+    // First, simulate a drag start to set activeDragItem
     const dragStartEvent: DragStartEvent = { active: createMockActive('inst1', 'daily_active'), activatorEvent: {} as any };
     act(() => { dndContextProps.onDragStart(dragStartEvent); });
-    const dragEndEvent: DragEndEvent = { active: createMockActive('inst1', 'daily_active'), over: createMockOver('inst3', 'daily_active'), delta: { x: 0, y: 0 }, collisions: null, activatorEvent: {} as any, };
-    act(() => { dndContextProps.onDragEnd(dragEndEvent); });
+    expect(screen.getByTestId('drag-overlay-content')).toBeInTheDocument();
+
+    // Now, simulate drag end
+    const dragEndEvent: DragEndEvent = {
+      active: createMockActive('inst1', 'daily_active'),
+      over: createMockOver('inst3', 'daily_active'), // Dropping inst1 over inst3
+      delta: { x: 0, y: 0 },
+      collisions: null,
+      activatorEvent: {} as any,
+    };
+    act(() => {
+      dndContextProps.onDragEnd(dragEndEvent);
+    });
     expect(screen.queryByTestId('drag-overlay-content')).not.toBeInTheDocument();
   });
 
   test('handleDragCancel clears activeDragItem and DragOverlay', () => {
-    const dailyActiveCol_dragCancel: KanbanColumnConfig = { id: 'daily_active', title: 'Today - Active', order: 0, kidId: 'kid1', createdAt: '', updatedAt: '' };
-    const userContext_dragCancel = { ...mockUserContextValue, getKanbanColumnConfigs: vi.fn(() => [dailyActiveCol_dragCancel]) };
-    renderKidKanbanBoard('kid1', mockContextValueFactory(), userContext_dragCancel);
+    renderKidKanbanBoard('kid1');
     const dragStartEvent: DragStartEvent = { active: createMockActive('inst1', 'daily_active'), activatorEvent: {} as any };
     act(() => { dndContextProps.onDragStart(dragStartEvent); });
-    const dragCancelEvent = { active: dragStartEvent.active, activatorEvent: {} as any };
-    act(() => { dndContextProps.onDragCancel(dragCancelEvent); });
+    expect(screen.getByTestId('drag-overlay-content')).toBeInTheDocument();
+
+    const dragCancelEvent = {
+        active: dragStartEvent.active,
+        activatorEvent: {} as any,
+    };
+    act(() => {
+      dndContextProps.onDragCancel(dragCancelEvent);
+    });
     expect(screen.queryByTestId('drag-overlay-content')).not.toBeInTheDocument();
   });
 
   test('handleDragEnd - reorders items in the same column (active)', () => {
-    const kidId_reorder = 'kid1';
-    const activeColumnId_reorder = 'daily_active';
-    const dailyActiveCol_reorder: KanbanColumnConfig = { id: activeColumnId_reorder, title: 'Today - Active', order: 0, kidId: kidId_reorder, createdAt: '', updatedAt: '' };
-    const userContext_reorder = { ...mockUserContextValue, getKanbanColumnConfigs: vi.fn(() => [dailyActiveCol_reorder]) };
-    resetMockChoreInstances(); 
-    let currentTestInstances_reorder = JSON.parse(JSON.stringify(mockChoreInstancesData.filter((i: ChoreInstance) => i.assignedKidId === kidId_reorder && !i.isComplete)));
-    let localKanbanChoreOrders_reorder: Record<string, string[]> = {};
-    let currentChoresContext_reorder = mockContextValueFactory(localKanbanChoreOrders_reorder);
-    currentChoresContext_reorder.choreInstances = currentTestInstances_reorder;
-    renderKidKanbanBoard(kidId_reorder, currentChoresContext_reorder, userContext_reorder);
-    const choreIds_reorder = currentTestInstances_reorder.map((c: ChoreInstance) => c.id); 
-    const dragEndEvent_reorder: DragEndEvent = { active: createMockActive('instX', activeColumnId_reorder, 2, choreIds_reorder), over: createMockOver('instY', activeColumnId_reorder, 3, choreIds_reorder), delta: { x: 0, y: 0 }, collisions: null, activatorEvent: {} as any };
-    
-    // Set the mock implementation on the context object that KidKanbanBoard will use
-    latestContextMocks!.updateKanbanChoreOrder = vi.fn((kId, colId, newOrder) => { // Use latestContextMocks
-        localKanbanChoreOrders_reorder[`${kId}-${colId}`] = newOrder;
+    renderKidKanbanBoard('kid1');
+    const activeColumnId = 'daily_active';
+    const kidId = 'kid1';
+
+    // Initial active chores for kid1, default order (inst1, inst3, instX, instY, instZ)
+    // Let's say inst1, inst3, instX, instY, instZ are active
+    const initialActiveChores = mockChoreInstancesData.filter(c => !c.isComplete);
+    const choreIds = initialActiveChores.map(c => c.id);
+
+    const dragEndEvent: DragEndEvent = {
+      active: createMockActive('instX', activeColumnId, 2, choreIds),
+      over: createMockOver('instY', activeColumnId, 3, choreIds),
+      delta: { x: 0, y: 0 },
+      collisions: null,
+      activatorEvent: {} as any,
+    };
+
+    act(() => {
+      dndContextProps.onDragEnd(dragEndEvent);
     });
 
-    act(() => { dndContextProps.onDragEnd(dragEndEvent_reorder); });
-    
-    const expectedOrder_reorder = ['inst1', 'inst3', 'instY', 'instX', 'instZ'];
-    expect(latestContextMocks?.updateKanbanChoreOrder).toHaveBeenCalledWith(kidId_reorder, activeColumnId_reorder, expectedOrder_reorder);
-
-    const updatedChoresContext_reorder = mockContextValueFactory(localKanbanChoreOrders_reorder);
-    updatedChoresContext_reorder.choreInstances = currentTestInstances_reorder; 
-    renderKidKanbanBoard(kidId_reorder, updatedChoresContext_reorder, userContext_reorder);
-    const callsAfterDrag_reorder = mockKanbanColumn.mock.calls.filter(call => call[0].column.id === activeColumnId_reorder);
-    const lastActiveColCall_reorder = callsAfterDrag_reorder.pop();
-    expect(lastActiveColCall_reorder?.[0].instances.map((c: ChoreInstance) => c.id)).toEqual(expectedOrder_reorder);
+    const activeColumn = mockKanbanColumn.mock.calls.find(call => call[0].column.id === activeColumnId)?.[0]?.column;
+    // Expected: inst1, inst3, instY, instX, instZ (if instX moved over instY)
+    // arrayMove(arr, 2, 3) on [inst1, inst3, instX, instY, instZ]
+    // results in [inst1, inst3, instY, instX, instZ]
+    const expectedOrder = ['inst1', 'inst3', 'instY', 'instX', 'instZ'];
+    expect(activeColumn?.chores.map((c: ChoreInstance) => c.id)).toEqual(expectedOrder);
+    expect(mockUpdateKanbanChoreOrder).toHaveBeenCalledWith(kidId, activeColumnId, expectedOrder);
   });
 
   test('handleDragEnd - moves item from active to completed column and updates status', () => {
-    const kidId_mvComp = 'kid1';
-    const activeColId_mvComp = 'daily_active'; const completedColId_mvComp = 'daily_completed';
-    const activeCol_mvComp: KanbanColumnConfig = { id: activeColId_mvComp, kidId: kidId_mvComp, title: 'Active', order: 0, createdAt: '', updatedAt: '' };
-    const completedCol_mvComp: KanbanColumnConfig = { id: completedColId_mvComp, kidId: kidId_mvComp, title: 'Completed', order: 1, createdAt: '', updatedAt: '' };
-    const userContext_mvComp = { ...mockUserContextValue, getKanbanColumnConfigs: vi.fn(() => [activeCol_mvComp, completedCol_mvComp]) };
-    let currentTestInstances_mvComp = JSON.parse(JSON.stringify(mockChoreInstancesData));
-    let inst1_mvComp = currentTestInstances_mvComp.find((i: ChoreInstance) => i.id === 'inst1');
-    if (inst1_mvComp) { inst1_mvComp.isComplete = false; inst1_mvComp.kanbanColumnId = undefined; }
-    let currentChoresContext_mvComp = mockContextValueFactory(); currentChoresContext_mvComp.choreInstances = currentTestInstances_mvComp; 
-    renderKidKanbanBoard(kidId_mvComp, currentChoresContext_mvComp, userContext_mvComp);
-    const dragEndEvent_mvComp: DragEndEvent = { active: createMockActive('inst1', activeCol_mvComp.id), over: createMockOver(completedCol_mvComp.id, completedCol_mvComp.id), delta: { x: 0, y: 0 }, collisions: null, activatorEvent: {} as any, };
-    
-    latestContextMocks!.updateChoreInstanceColumn = vi.fn((instanceId, newColumnId) => {
-      currentTestInstances_mvComp = currentTestInstances_mvComp.map((inst: ChoreInstance) => {
-        if (inst.id === instanceId) { const updatedInst = { ...inst, kanbanColumnId: newColumnId }; if (newColumnId === completedColId_mvComp) updatedInst.isComplete = true; return updatedInst; } return inst;
-      });
+    const kidId = 'kid1';
+    const dynamicCol1: KanbanColumnConfig = { id: 'daily_active', kidId, title: 'Active', order: 0 };
+    const dynamicCol2: KanbanColumnConfig = { id: 'daily_completed', kidId, title: 'Completed', order: 1 };
+    mockGetKanbanColumnConfigs.mockReturnValue([dynamicCol1, dynamicCol2]);
+
+    renderKidKanbanBoard(kidId, mockContextValueFactory(mockKanbanChoreOrdersData));
+
+    const dragEndEvent: DragEndEvent = {
+      active: createMockActive('inst1', dynamicCol1.id),
+      over: createMockOver(dynamicCol2.id, dynamicCol2.id),
+      delta: { x: 0, y: 0 },
+      collisions: null,
+      activatorEvent: {} as any,
+    };
+
+    act(() => {
+      dndContextProps.onDragEnd(dragEndEvent);
     });
-    
-    act(() => { dndContextProps.onDragEnd(dragEndEvent_mvComp); });
-    expect(latestContextMocks?.updateChoreInstanceColumn).toHaveBeenCalledWith('inst1', completedCol_mvComp.id);
-    const updatedChoresContext_mvComp = mockContextValueFactory(); updatedChoresContext_mvComp.choreInstances = currentTestInstances_mvComp; 
-    renderKidKanbanBoard(kidId_mvComp, updatedChoresContext_mvComp, userContext_mvComp); 
-    const calls_mvComp = mockKanbanColumn.mock.calls.filter(call => call[0].column.id === activeCol_mvComp.id || call[0].column.id === completedCol_mvComp.id);
-    expect(calls_mvComp.find(c => c[0].column.id === activeCol_mvComp.id)?.pop()?.[0].instances.find((i:ChoreInstance) => i.id === 'inst1')).toBeUndefined();
-    const movedItem_mvComp = calls_mvComp.find(c => c[0].column.id === completedCol_mvComp.id)?.pop()?.[0].instances.find((i:ChoreInstance) => i.id === 'inst1');
-    expect(movedItem_mvComp).toBeDefined(); expect(movedItem_mvComp?.kanbanColumnId).toBe(completedCol_mvComp.id); expect(movedItem_mvComp?.isComplete).toBe(true);
+
+    expect(mockUpdateChoreInstanceColumn).toHaveBeenCalledWith('inst1', dynamicCol2.id);
+
+    const col1Data = mockKanbanColumn.mock.calls.find(call => call[0].column.id === dynamicCol1.id)?.[0]?.column;
+    expect(col1Data?.chores.find((c: ChoreInstance) => c.id === 'inst1')).toBeUndefined();
+
+    const col2Data = mockKanbanColumn.mock.calls.find(call => call[0].column.id === dynamicCol2.id)?.[0]?.column;
+    const movedItem = col2Data?.chores.find((c: ChoreInstance) => c.id === 'inst1');
+    expect(movedItem).toBeDefined();
+    expect(movedItem?.kanbanColumnId).toBe(dynamicCol2.id);
   });
 
   test('handleDragEnd - moves item between dynamic columns and updates its kanbanColumnId (status unchanged)', () => {
-    const kidId_mvDyn = 'kid1';
-    const dynCol1_mvDyn: KanbanColumnConfig = { id: 'dynCol1', kidId: kidId_mvDyn, title: 'Dynamic Col 1', order: 0, createdAt: '', updatedAt: '' };
-    const dynCol2_mvDyn: KanbanColumnConfig = { id: 'dynCol2', kidId: kidId_mvDyn, title: 'Dynamic Col 2', order: 1, createdAt: '', updatedAt: '' };
-    const userContext_mvDyn = { ...mockUserContextValue, getKanbanColumnConfigs: vi.fn(() => [dynCol1_mvDyn, dynCol2_mvDyn]) };
-    let currentTestInstances_mvDyn = JSON.parse(JSON.stringify(mockChoreInstancesData));
-    const inst2Idx = currentTestInstances_mvDyn.findIndex((i: ChoreInstance) => i.id === 'inst2');
-    if (inst2Idx !== -1) { currentTestInstances_mvDyn[inst2Idx] = { ...currentTestInstances_mvDyn[inst2Idx], kanbanColumnId: dynCol1_mvDyn.id, isComplete: true }; }
-    let currentChoresContext_mvDyn = mockContextValueFactory(); currentChoresContext_mvDyn.choreInstances = currentTestInstances_mvDyn;
-    renderKidKanbanBoard(kidId_mvDyn, currentChoresContext_mvDyn, userContext_mvDyn);
-    const dragEndEvent_mvDyn: DragEndEvent = { active: createMockActive('inst2', dynCol1_mvDyn.id), over: createMockOver(dynCol2_mvDyn.id, dynCol2_mvDyn.id), delta: { x: 0, y: 0 }, collisions: null, activatorEvent: {} as any, };
-    
-    latestContextMocks!.updateChoreInstanceColumn = vi.fn((instanceId, newColumnId) => { currentTestInstances_mvDyn = currentTestInstances_mvDyn.map((inst: ChoreInstance) => inst.id === instanceId ? { ...inst, kanbanColumnId: newColumnId } : inst ); });
-    latestContextMocks!.toggleChoreInstanceComplete = vi.fn(); 
+    const kidId = 'kid1';
+    const dynamicCol1: KanbanColumnConfig = { id: 'dynCol1', kidId, title: 'Dynamic Col 1', order: 0 };
+    const dynamicCol2: KanbanColumnConfig = { id: 'dynCol2', kidId, title: 'Dynamic Col 2', order: 1 };
+    mockGetKanbanColumnConfigs.mockReturnValue([dynamicCol1, dynamicCol2]);
 
-    act(() => { dndContextProps.onDragEnd(dragEndEvent_mvDyn); });
-    expect(latestContextMocks?.updateChoreInstanceColumn).toHaveBeenCalledWith('inst2', dynCol2_mvDyn.id);
-    expect(latestContextMocks?.toggleChoreInstanceComplete).not.toHaveBeenCalled(); 
-    const updatedChoresContext_mvDyn = mockContextValueFactory(); updatedChoresContext_mvDyn.choreInstances = currentTestInstances_mvDyn;
-    renderKidKanbanBoard(kidId_mvDyn, updatedChoresContext_mvDyn, userContext_mvDyn);
-    const calls_mvDyn = mockKanbanColumn.mock.calls.filter(call => call[0].column.id === dynCol1_mvDyn.id || call[0].column.id === dynCol2_mvDyn.id);
-    expect(calls_mvDyn.find(c => c[0].column.id === dynCol1_mvDyn.id)?.pop()?.[0].instances.find((i:ChoreInstance) => i.id === 'inst2')).toBeUndefined();
-    const movedItem_mvDyn = calls_mvDyn.find(c => c[0].column.id === dynCol2_mvDyn.id)?.pop()?.[0].instances.find((i:ChoreInstance) => i.id === 'inst2');
-    expect(movedItem_mvDyn).toBeDefined(); expect(movedItem_mvDyn?.kanbanColumnId).toBe(dynCol2_mvDyn.id); expect(movedItem_mvDyn?.isComplete).toBe(true); 
+    mockChoreInstancesData = mockChoreInstancesData.map(inst =>
+      inst.id === 'inst2' ? { ...inst, kanbanColumnId: dynamicCol1.id, isComplete: true } : inst
+    );
+
+    renderKidKanbanBoard(kidId, mockContextValueFactory(mockKanbanChoreOrdersData));
+
+    const dragEndEvent: DragEndEvent = {
+      active: createMockActive('inst2', dynamicCol1.id),
+      over: createMockOver(dynamicCol2.id, dynamicCol2.id),
+      delta: { x: 0, y: 0 },
+      collisions: null,
+      activatorEvent: {} as any,
+    };
+
+    act(() => {
+      dndContextProps.onDragEnd(dragEndEvent);
+    });
+
+    expect(mockUpdateChoreInstanceColumn).toHaveBeenCalledWith('inst2', dynamicCol2.id);
+    expect(mockToggleChoreInstanceComplete).not.toHaveBeenCalled();
+
+    const col1Data = mockKanbanColumn.mock.calls.find(call => call[0].column.id === dynamicCol1.id)?.[0]?.column;
+    expect(col1Data?.chores.find((c: ChoreInstance) => c.id === 'inst2')).toBeUndefined();
+
+    const col2Data = mockKanbanColumn.mock.calls.find(call => call[0].column.id === dynamicCol2.id)?.[0]?.column;
+    const movedItem = col2Data?.chores.find((c: ChoreInstance) => c.id === 'inst2');
+    expect(movedItem).toBeDefined();
+    expect(movedItem?.kanbanColumnId).toBe(dynamicCol2.id);
+    expect(movedItem?.isComplete).toBe(true);
   });
 
+
   test('handleDragEnd - no change if dropped on self and order is same', () => {
-    const kidId_noSelf = 'kid1'; const activeColumnId_noSelf = 'daily_active';
-    const dailyActiveCol_noSelf: KanbanColumnConfig = { id: activeColumnId_noSelf, title: 'Today - Active', order: 0, kidId: kidId_noSelf, createdAt: '', updatedAt: '' };
-    const userContext_noSelf = { ...mockUserContextValue, getKanbanColumnConfigs: vi.fn(() => [dailyActiveCol_noSelf]) };
-    renderKidKanbanBoard(kidId_noSelf, mockContextValueFactory(), userContext_noSelf);
-    const initialCalls_noSelf = mockKanbanColumn.mock.calls.filter(call => call[0].column.id === activeColumnId_noSelf);
-    const lastInitialCall_noSelf = initialCalls_noSelf[initialCalls_noSelf.length - 1];
-    const initialActiveChores_noSelf = lastInitialCall_noSelf?.[0].instances;
-    const dragEndEvent_noSelf: DragEndEvent = { active: createMockActive('inst1', activeColumnId_noSelf, 0, ['inst1', 'inst3']), over: createMockOver('inst1', activeColumnId_noSelf, 0, ['inst1', 'inst3']), delta: { x: 0, y: 0 }, collisions: null, activatorEvent: {} as any, };
-    act(() => { dndContextProps.onDragEnd(dragEndEvent_noSelf); });
-    const finalCalls_noSelf = mockKanbanColumn.mock.calls.filter(call => call[0].column.id === activeColumnId_noSelf);
-    const lastFinalCall_noSelf = finalCalls_noSelf[finalCalls_noSelf.length - 1];
-    const finalActiveChores_noSelf = lastFinalCall_noSelf?.[0].instances;
-    expect(finalActiveChores_noSelf?.map((c:ChoreInstance) => c.id)).toEqual(initialActiveChores_noSelf?.map((c:ChoreInstance) => c.id));
-    expect(latestContextMocks?.toggleChoreInstanceComplete).not.toHaveBeenCalled();
+    renderKidKanbanBoard('kid1');
+    const activeColumnId = 'daily_active';
+    const initialActiveChores = mockKanbanColumn.mock.calls.find(call => call[0].column.id === activeColumnId)?.[0]?.column.chores;
+
+    const dragEndEvent: DragEndEvent = {
+      active: createMockActive('inst1', activeColumnId, 0, ['inst1', 'inst3']),
+      over: createMockOver('inst1', activeColumnId, 0, ['inst1', 'inst3']), // Dropped on self, same index
+      delta: { x: 0, y: 0 },
+      collisions: null,
+      activatorEvent: {} as any,
+    };
+
+    act(() => {
+      dndContextProps.onDragEnd(dragEndEvent);
+    });
+
+    const finalActiveChores = mockKanbanColumn.mock.calls.find(call => call[0].column.id === activeColumnId)?.[0]?.column.chores;
+    expect(finalActiveChores?.map((c:ChoreInstance) => c.id)).toEqual(initialActiveChores?.map((c:ChoreInstance) => c.id));
+    expect(mockToggleChoreInstanceComplete).not.toHaveBeenCalled();
   });
 
   test('handleDragEnd - no action if dropped outside any droppable area (over is null)', () => {
-    const kidId_dropNull = 'kid1';
-    const dailyActiveCol_dropNull: KanbanColumnConfig = { id: 'daily_active', title: 'Today - Active', order: 0, kidId: kidId_dropNull, createdAt: '', updatedAt: '' };
-    const userContext_dropNull = { ...mockUserContextValue, getKanbanColumnConfigs: vi.fn(() => [dailyActiveCol_dropNull]) };
-    renderKidKanbanBoard(kidId_dropNull, mockContextValueFactory(), userContext_dropNull);
-    const initialCalls_dropNull = [...mockKanbanColumn.mock.calls]; 
-    const dragEndEvent_dropNull: DragEndEvent = { active: createMockActive('inst1', 'daily_active'), over: null, delta: { x: 0, y: 0 }, collisions: null, activatorEvent: {} as any, };
-    act(() => { dndContextProps.onDragEnd(dragEndEvent_dropNull); });
-    const finalCalls_dropNull = [...mockKanbanColumn.mock.calls];
-    expect(finalCalls_dropNull.length).toEqual(initialCalls_dropNull.length);
-    expect(latestContextMocks?.toggleChoreInstanceComplete).not.toHaveBeenCalled();
+    renderKidKanbanBoard('kid1');
+    const initialColumnsState = JSON.stringify(mockKanbanColumn.mock.calls.map(call => call[0].column));
+
+    const dragEndEvent: DragEndEvent = {
+      active: createMockActive('inst1', 'daily_active'),
+      over: null, // Dropped outside
+      delta: { x: 0, y: 0 },
+      collisions: null,
+      activatorEvent: {} as any,
+    };
+
+    act(() => {
+      dndContextProps.onDragEnd(dragEndEvent);
+    });
+
+    const finalColumnsState = JSON.stringify(mockKanbanColumn.mock.calls.map(call => call[0].column));
+    expect(finalColumnsState).toEqual(initialColumnsState); // No change to columns
+    expect(mockToggleChoreInstanceComplete).not.toHaveBeenCalled();
   });
 
   test('applies custom order from kanbanChoreOrders when sortBy is "instanceDate"', () => {
-    const kidId_co = 'kid1'; const activeColumnId_co = 'daily_active';
-    const customOrder_co = ['instZ', 'instX', 'instY']; 
-    let localOrders_co: Record<string, string[]> = { [`${kidId_co}-${activeColumnId_co}`]: customOrder_co };
-    const dailyActiveCol_co: KanbanColumnConfig = { id: activeColumnId_co, title: 'Today - Active', order: 0, kidId: kidId_co, createdAt: '', updatedAt: '' };
-    const userContext_co = { ...mockUserContextValue, getKanbanColumnConfigs: vi.fn(() => [dailyActiveCol_co]) };
-    let choresContext_co = mockContextValueFactory(localOrders_co); 
-    resetMockChoreInstances(); choresContext_co.choreInstances = [...mockChoreInstancesData]; 
-    renderKidKanbanBoard(kidId_co, choresContext_co, userContext_co);
-    const sortBySelect_co = screen.getByLabelText(/Sort by:/i);
-    expect(sortBySelect_co).toHaveValue('instanceDate');
-    const calls_co = mockKanbanColumn.mock.calls.filter(call => call[0].column.id === activeColumnId_co);
-    const renderedChores_co = calls_co[calls_co.length - 1]?.[0].instances;
-    expect(renderedChores_co?.map((c: ChoreInstance) => c.id)).toEqual([...customOrder_co, 'inst1', 'inst3']);
+    const kidId = 'kid1';
+    const activeColumnId = 'daily_active';
+    const customOrder = ['instZ', 'instX', 'instY']; // Define a custom order for some of kid1's active chores
+
+    // inst1, inst3 are other active chores for kid1 not in this custom order.
+    // Default active order for kid1 if no custom: inst1, inst3, instX, instY, instZ (by ID or original add order)
+    // Expected with custom: instZ, instX, instY, then inst1, inst3 (appended, sorted by date/default)
+
+    mockKanbanChoreOrdersData[`${kidId}-${activeColumnId}`] = customOrder;
+
+    renderKidKanbanBoard(kidId, mockContextValueFactory(mockKanbanChoreOrdersData));
+
+    // Ensure sort is "My Order / Due Date" (which is 'instanceDate' internally)
+    const sortBySelect = screen.getByLabelText(/Sort by:/i);
+    expect(sortBySelect).toHaveValue('instanceDate');
+
+    const activeColumn = mockKanbanColumn.mock.calls.find(call => call[0].column.id === activeColumnId)?.[0]?.column;
+    const renderedOrder = activeColumn.chores.map((c: ChoreInstance) => c.id);
+
+    // Chores in customOrder should appear first, in that order.
+    // Other chores (inst1, inst3) should appear after, sorted by default (e.g., instanceDate or their original order).
+    // Assuming inst1 and inst3 are sorted by their ID here as instanceDate is same for all.
+    const expectedRenderOrder = [...customOrder, 'inst1', 'inst3'];
+    expect(renderedOrder).toEqual(expectedRenderOrder);
   });
 
   test('clears custom order for current columns when explicit sort is chosen', async () => {
-    const user_clearOrderTest = userEvent.setup(); 
-    const kidId_clearOrderTest = 'kid1'; 
-    const activeColumnId_clearOrderTest = 'daily_active'; 
-    const completedColumnId_clearOrderTest = 'daily_completed'; 
-    const dailyActiveCol_clearOrderTest: KanbanColumnConfig = { id: activeColumnId_clearOrderTest, title: 'Today - Active', order: 0, kidId: kidId_clearOrderTest, createdAt: '', updatedAt: '' };
-    const dailyCompletedCol_clearOrderTest: KanbanColumnConfig = { id: completedColumnId_clearOrderTest, title: 'Today - Completed', order: 1, kidId: kidId_clearOrderTest, createdAt: '', updatedAt: '' };
-    const userContextWithDailyCols_clearOrderTest = { ...mockUserContextValue, getKanbanColumnConfigs: vi.fn(() => [dailyActiveCol_clearOrderTest, dailyCompletedCol_clearOrderTest]) };
-    let localKanbanChoreOrders_clearOrderTest: Record<string, string[]> = { 
-      [`${kidId_clearOrderTest}-${activeColumnId_clearOrderTest}`]: ['instZ', 'instX', 'instY'],
-      [`${kidId_clearOrderTest}-${completedColumnId_clearOrderTest}`]: ['inst2'] 
-    };
-    resetMockChoreInstances(); 
-    let currentChoresContext_clearOrderTest = mockContextValueFactory(localKanbanChoreOrders_clearOrderTest); 
-    currentChoresContext_clearOrderTest.choreInstances = [...mockChoreInstancesData];
-    renderKidKanbanBoard(kidId_clearOrderTest, currentChoresContext_clearOrderTest, userContextWithDailyCols_clearOrderTest);
-    let activeColumnCalls_clearOrderTest = mockKanbanColumn.mock.calls.filter(call => call[0].column.id === activeColumnId_clearOrderTest); 
-    expect(activeColumnCalls_clearOrderTest.pop()?.[0].instances.map((c: ChoreInstance) => c.id)).toEqual(['instZ', 'instX', 'instY', 'inst1', 'inst3']);
-    
-    latestContextMocks!.updateKanbanChoreOrder = vi.fn((kId, colId, newOrder) => { 
-        localKanbanChoreOrders_clearOrderTest[`${kId}-${colId}`] = newOrder;
-    });
-    
-    const sortBySelect_clearOrderTest = screen.getByLabelText(/Sort by:/i); 
-    await user_clearOrderTest.selectOptions(sortBySelect_clearOrderTest, 'title'); 
-    expect(latestContextMocks?.updateKanbanChoreOrder).toHaveBeenCalledWith(kidId_clearOrderTest, activeColumnId_clearOrderTest, []);
-    expect(latestContextMocks?.updateKanbanChoreOrder).toHaveBeenCalledWith(kidId_clearOrderTest, completedColumnId_clearOrderTest, []);
-    
-    let updatedChoresContext_clearOrderTest = mockContextValueFactory(localKanbanChoreOrders_clearOrderTest);  
-    updatedChoresContext_clearOrderTest.choreInstances = [...mockChoreInstancesData]; 
-    renderKidKanbanBoard(kidId_clearOrderTest, updatedChoresContext_clearOrderTest, userContextWithDailyCols_clearOrderTest);
-    activeColumnCalls_clearOrderTest = mockKanbanColumn.mock.calls.filter(call => call[0].column.id === activeColumnId_clearOrderTest); 
-    expect(activeColumnCalls_clearOrderTest.pop()?.[0].instances.map((c: ChoreInstance) => c.id)).toEqual(['instX', 'instY', 'instZ', 'inst3', 'inst1']);
+    const user = userEvent.setup();
+    const kidId = 'kid1';
+    const activeColumnId = 'daily_active';
+    const completedColumnId = 'daily_completed'; // Assuming this column might also be visible
+
+    // Setup initial custom order
+    mockKanbanChoreOrdersData[`${kidId}-${activeColumnId}`] = ['instZ', 'instX', 'instY'];
+    mockKanbanChoreOrdersData[`${kidId}-${completedColumnId}`] = ['inst2']; // Example for completed
+
+    renderKidKanbanBoard(kidId, mockContextValueFactory(mockKanbanChoreOrdersData));
+
+    // Verify custom order is initially applied (sortBy is 'instanceDate' by default)
+    let activeColumn = mockKanbanColumn.mock.calls.find(call => call[0].column.id === activeColumnId)?.[0]?.column;
+    expect(activeColumn.chores.map((c: ChoreInstance) => c.id)).toEqual(['instZ', 'instX', 'instY', 'inst1', 'inst3']);
+
+    // User changes sort to "Title"
+    const sortBySelect = screen.getByLabelText(/Sort by:/i);
+    await user.selectOptions(sortBySelect, 'title');
+
+    // Verify updateKanbanChoreOrder was called to clear orders for visible columns
+    expect(mockUpdateKanbanChoreOrder).toHaveBeenCalledWith(kidId, activeColumnId, []);
+    expect(mockUpdateKanbanChoreOrder).toHaveBeenCalledWith(kidId, completedColumnId, []);
+
+    // Verify chores are now sorted by title (mockKanbanColumn receives chores sorted by KidKanbanBoard's useEffect)
+    // Titles: WalkDog(def1,inst1), CleanRoom(def2,inst2), DoHomework(def3,inst3), ChoreX(def5,instX), ChoreY(def6,instY), ChoreZ(def7,instZ)
+    // Active chores for kid1: inst1, inst3, instX, instY, instZ
+    // Titles: WalkDog, DoHomework, ChoreX, ChoreY, ChoreZ
+    // Expected ASC title order: ChoreX, ChoreY, ChoreZ, DoHomework, WalkDog
+    activeColumn = mockKanbanColumn.mock.calls.find(call => call[0].column.id === activeColumnId)?.[0]?.column;
+    expect(activeColumn.chores.map((c: ChoreInstance) => c.id)).toEqual(['instX', 'instY', 'instZ', 'inst3', 'inst1']);
+
+    // Verify ARIA attributes for the columns container
+    expect(screen.getByLabelText('Kanban board columns')).toHaveAttribute('role', 'list');
   });
 
   test('after explicit sort clears custom order, switching back to "My Order" uses default sort', async () => {
-    const user_aesTest = userEvent.setup(); 
-    const kidId_aesTest = 'kid1'; 
-    const activeColumnId_aesTest = 'daily_active'; 
-    const dailyActiveCol_aesTest: KanbanColumnConfig = { id: activeColumnId_aesTest, title: 'Today - Active', order: 0, kidId: kidId_aesTest, createdAt: '', updatedAt: '' }; 
-    const userContextWithDailyCols_aesTest = { ...mockUserContextValue, getKanbanColumnConfigs: vi.fn(() => [dailyActiveCol_aesTest]) }; 
-    let localKanbanChoreOrders_aesTest: Record<string, string[]> = { [`${kidId_aesTest}-${activeColumnId_aesTest}`]: ['instZ', 'instX', 'instY'] };
-    resetMockChoreInstances();
-    let currentChoresContext_aesTest = mockContextValueFactory(localKanbanChoreOrders_aesTest); 
-    currentChoresContext_aesTest.choreInstances = [...mockChoreInstancesData];
-    renderKidKanbanBoard(kidId_aesTest, currentChoresContext_aesTest, userContextWithDailyCols_aesTest);
-    const sortBySelect_aesTest = screen.getByLabelText(/Sort by:/i); 
-    
-    latestContextMocks!.updateKanbanChoreOrder = vi.fn((kId, colId, newOrder) => { 
-        localKanbanChoreOrders_aesTest[`${kId}-${colId}`] = newOrder;
-    });
-    
-    await user_aesTest.selectOptions(sortBySelect_aesTest, 'title');
-    expect(latestContextMocks?.updateKanbanChoreOrder).toHaveBeenCalledWith(kidId_aesTest, activeColumnId_aesTest, []);
-    
-    let contextAfterTitleSort_aesTest = mockContextValueFactory(localKanbanChoreOrders_aesTest);  
-    contextAfterTitleSort_aesTest.choreInstances = [...mockChoreInstancesData];
-    renderKidKanbanBoard(kidId_aesTest, contextAfterTitleSort_aesTest, userContextWithDailyCols_aesTest);
-    
-    (latestContextMocks?.updateKanbanChoreOrder as vi.Mock).mockClear(); 
-    await user_aesTest.selectOptions(sortBySelect_aesTest, 'instanceDate');
-    expect(latestContextMocks?.updateKanbanChoreOrder).not.toHaveBeenCalled(); 
-    const activeColumnCalls_aesTest = mockKanbanColumn.mock.calls.filter(call => call[0].column.id === activeColumnId_aesTest); 
-    const activeColumn_aesTest = activeColumnCalls_aesTest[activeColumnCalls_aesTest.length -1]?.[0]?.column; 
-    const defaultOrder_aesTest = contextAfterTitleSort_aesTest.choreInstances  
-        .filter((c:ChoreInstance) => !c.isComplete && c.assignedKidId === kidId_aesTest && c.kanbanColumnId !== 'daily_completed') 
-        .sort((a,b) => new Date(a.instanceDate).getTime() - new Date(b.instanceDate).getTime() || a.id.localeCompare(b.id)) 
+    const user = userEvent.setup();
+    const kidId = 'kid1';
+    const activeColumnId = 'daily_active';
+
+    mockKanbanChoreOrdersData[`${kidId}-${activeColumnId}`] = ['instZ', 'instX', 'instY']; // Initial custom order
+
+    const contextToUse = mockContextValueFactory(mockKanbanChoreOrdersData);
+    renderKidKanbanBoard(kidId, contextToUse);
+
+    const sortBySelect = screen.getByLabelText(/Sort by:/i);
+
+    // 1. Apply explicit sort (e.g., Title), which should clear custom order for daily_active
+    await user.selectOptions(sortBySelect, 'title');
+    expect(mockUpdateKanbanChoreOrder).toHaveBeenCalledWith(kidId, activeColumnId, []);
+
+    // Simulate the context actually clearing the order for the next step
+    delete mockKanbanChoreOrdersData[`${kidId}-${activeColumnId}`];
+    // Re-render or ensure context update propagates if `renderKidKanbanBoard` doesn't re-read mockKanbanChoreOrdersData directly
+    // For this test, we will assume the effect of updateKanbanChoreOrder has cleared it from the perspective of ChoresContext
+
+    // 2. User switches back to "My Order / Due Date"
+    await user.selectOptions(sortBySelect, 'instanceDate');
+
+    // Verify chores are now in default instanceDate order (all have same date, so original/ID order)
+    // Active kid1 chores: inst1, inst3, instX, instY, instZ
+    // Default order (assuming by ID as dates are same): inst1, inst3, instX, instY, instZ
+    const activeColumn = mockKanbanColumn.mock.calls.find(call => call[0].column.id === activeColumnId)?.[0]?.column;
+    const defaultOrder = mockChoreInstancesData
+        .filter(c => !c.isComplete)
+        .sort((a,b) => new Date(a.instanceDate).getTime() - new Date(b.instanceDate).getTime() || a.id.localeCompare(b.id)) // Example default sort
         .map(c => c.id);
-    expect(activeColumn_aesTest.chores.map((c: ChoreInstance) => c.id)).toEqual(defaultOrder_aesTest); 
+
+    expect(activeColumn.chores.map((c: ChoreInstance) => c.id)).toEqual(defaultOrder);
   });
 
   test('calls generateInstancesForPeriod with default column ID from UserContext', () => {
-    const kidId_userColsTest = 'kid1'; 
-    const userCols_userColsTest: KanbanColumnConfig[] = [ 
-      { id: 'col1_todo', kidId: kidId_userColsTest, title: 'To Do', order: 0, createdAt: '', updatedAt: '' },
-      { id: 'col2_prog', kidId: kidId_userColsTest, title: 'In Progress', order: 1, createdAt: '', updatedAt: '' },
+    const kidId = 'kid1';
+    const userCols: KanbanColumnConfig[] = [
+      { id: 'col1_todo', kidId, title: 'To Do', order: 0, createdAt: '', updatedAt: '' },
+      { id: 'col2_prog', kidId, title: 'In Progress', order: 1, createdAt: '', updatedAt: '' },
     ];
-    const mockGetKanbanConfigs_userColsTest = vi.fn(() => userCols_userColsTest);
-    const userContext_userColsTest = { ...mockUserContextValue, getKanbanColumnConfigs: mockGetKanbanConfigs_userColsTest};
-    renderKidKanbanBoard(kidId_userColsTest, mockContextValueFactory(), userContext_userColsTest);
-    const todayStr_userColsTest = (dateUtils.getTodayDateString as vi.Mock)(); 
-    expect(latestContextMocks?.generateInstancesForPeriod).toHaveBeenCalledWith(todayStr_userColsTest, todayStr_userColsTest, userCols_userColsTest[0].id);
+    mockGetKanbanColumnConfigs.mockReturnValue(userCols); // Mock UserContext to return these columns
+
+    renderKidKanbanBoard(kidId);
+
+    // Verify ARIA attributes for the columns container
+    expect(screen.getByLabelText('Kanban board columns')).toHaveAttribute('role', 'list');
+
+    const todayStr = getTodayDateString();
+    // Expect generateInstancesForPeriod to be called with the ID of the first column ('col1_todo')
+    expect(mockGenerateInstancesForPeriod).toHaveBeenCalledWith(todayStr, todayStr, userCols[0].id);
   });
 
   test('displays a message and no columns if no columns are configured for the kid', () => {
-    const kidId_noColsTest = 'kid_no_cols'; 
-    const mockGetKanbanConfigs_noColsTest = vi.fn(() => []);
-    const userContext_noColsTest = { ...mockUserContextValue, getKanbanColumnConfigs: mockGetKanbanConfigs_noColsTest};
-    renderKidKanbanBoard(kidId_noColsTest, mockContextValueFactory(), userContext_noColsTest);
+    const kidId = 'kid_no_cols';
+    mockGetKanbanColumnConfigs.mockReturnValue([]); // No columns configured
+
+    renderKidKanbanBoard(kidId);
+
+    // Check for the message
     expect(screen.getByText(/No Kanban columns are set up for this kid yet./i)).toBeInTheDocument();
+    expect(screen.getByText(/Please go to Settings > Kanban Column Settings to configure them./i)).toBeInTheDocument();
+
+    // Check that no KanbanColumn mocks were rendered
+    expect(screen.queryByTestId(/mock-kanban-column-/)).not.toBeInTheDocument();
   });
 
   test('calls generateInstancesForPeriod with undefined default column ID if no columns configured', () => {
-    const kidId_undefColTest = 'kid_no_cols_for_gen'; 
-    const mockGetKanbanConfigs_undefColTest = vi.fn(() => []);
-    const userContext_undefColTest = { ...mockUserContextValue, getKanbanColumnConfigs: mockGetKanbanConfigs_undefColTest};
-    renderKidKanbanBoard(kidId_undefColTest, mockContextValueFactory(), userContext_undefColTest);
-    const todayStr_undefColTest = (dateUtils.getTodayDateString as vi.Mock)();
-    expect(latestContextMocks?.generateInstancesForPeriod).toHaveBeenCalledWith(todayStr_undefColTest, todayStr_undefColTest, undefined);
+    const kidId = 'kid_no_cols_for_gen';
+    mockGetKanbanColumnConfigs.mockReturnValue([]); // No columns configured
+
+    renderKidKanbanBoard(kidId);
+
+    const todayStr = getTodayDateString();
+    expect(mockGenerateInstancesForPeriod).toHaveBeenCalledWith(todayStr, todayStr, undefined);
   });
 
   test('displays and clears action feedback message on successful inter-column drag', async () => {
-    vi.useFakeTimers(); 
-    const kidId_feedbackTest = 'kid1';
-    const dynamicCol1_feedbackTest: KanbanColumnConfig = { id: 'dynCol1', kidId: kidId_feedbackTest, title: 'Column Alpha', order: 0, createdAt: 't', updatedAt: 't' };
-    const dynamicCol2_feedbackTest: KanbanColumnConfig = { id: 'dynCol2', kidId: kidId_feedbackTest, title: 'Column Beta', order: 1, createdAt: 't', updatedAt: 't' };
-    const userContext_feedbackTest = { ...mockUserContextValue, getKanbanColumnConfigs: vi.fn(() => [dynamicCol1_feedbackTest, dynamicCol2_feedbackTest])};
-    let currentTestInstances_feedbackTest = JSON.parse(JSON.stringify(mockChoreInstancesData));
-    const instX_idx = currentTestInstances_feedbackTest.findIndex((i:ChoreInstance) => i.id === 'instX');
-    if (instX_idx !== -1) currentTestInstances_feedbackTest[instX_idx].kanbanColumnId = dynamicCol1_feedbackTest.id;
-    let choresContext_feedbackTest = mockContextValueFactory();
-    choresContext_feedbackTest.choreInstances = currentTestInstances_feedbackTest;
-    const choreDefForInstX_feedbackTest = choresContext_feedbackTest.choreDefinitions.find(d => d.id === 'def5'); 
-    renderKidKanbanBoard(kidId_feedbackTest, choresContext_feedbackTest, userContext_feedbackTest);
-    const dragStartEvent_feedbackTest: DragStartEvent = { active: createMockActive('instX', dynamicCol1_feedbackTest.id), activatorEvent: {} as any };
-    act(() => { dndContextProps.onDragStart(dragStartEvent_feedbackTest); });
-    const dragEndEvent_feedbackTest: DragEndEvent = { active: createMockActive('instX', dynamicCol1_feedbackTest.id), over: createMockOver(dynamicCol2_feedbackTest.id, dynamicCol2_feedbackTest.id), delta: { x: 0, y: 0 }, collisions: null, activatorEvent: {} as any, };
-    
-    latestContextMocks!.updateChoreInstanceColumn = vi.fn((instanceId, newColumnId) => { 
-      currentTestInstances_feedbackTest = currentTestInstances_feedbackTest.map((inst: ChoreInstance) => 
-        inst.id === instanceId ? { ...inst, kanbanColumnId: newColumnId } : inst
-      );
+    vi.useFakeTimers(); // Use fake timers for this test
+
+    const kidId = 'kid1';
+    const dynamicCol1: KanbanColumnConfig = { id: 'dynCol1', kidId, title: 'Column Alpha', order: 0, createdAt: 't', updatedAt: 't' };
+    const dynamicCol2: KanbanColumnConfig = { id: 'dynCol2', kidId, title: 'Column Beta', order: 1, createdAt: 't', updatedAt: 't' };
+    mockGetKanbanColumnConfigs.mockReturnValue([dynamicCol1, dynamicCol2]);
+
+    // Ensure instX is in dynCol1 initially and has a definition for its title
+    mockChoreInstancesData = mockChoreInstancesData.map(inst =>
+      inst.id === 'instX' ? { ...inst, kanbanColumnId: dynamicCol1.id } : inst
+    );
+    const choreDefForInstX = mockChoreDefinitions.find(d => d.id === 'def5'); // 'Chore X (for custom order)'
+
+    renderKidKanbanBoard(kidId, mockContextValueFactory(mockKanbanChoreOrdersData));
+
+    // 1. Simulate Drag Start to populate activeDragItem
+    const dragStartEvent: DragStartEvent = {
+      active: createMockActive('instX', dynamicCol1.id),
+      activatorEvent: {} as any,
+    };
+    act(() => {
+      dndContextProps.onDragStart(dragStartEvent);
     });
-    act(() => { dndContextProps.onDragEnd(dragEndEvent_feedbackTest); });
-    const updatedChoresContext_feedbackTest = mockContextValueFactory();
-    updatedChoresContext_feedbackTest.choreInstances = currentTestInstances_feedbackTest;
-    renderKidKanbanBoard(kidId_feedbackTest, updatedChoresContext_feedbackTest, userContext_feedbackTest);
-    const feedbackMessage_feedbackTest = await screen.findByRole('status'); 
-    expect(feedbackMessage_feedbackTest).toHaveTextContent(`${choreDefForInstX_feedbackTest!.title} moved to ${dynamicCol2_feedbackTest.title}.`);
-    act(() => { vi.advanceTimersByTime(3000); });
+
+    // 2. Simulate Drag End (moving instX from dynCol1 to dynCol2)
+    const dragEndEvent: DragEndEvent = {
+      active: createMockActive('instX', dynamicCol1.id),
+      over: createMockOver(dynamicCol2.id, dynamicCol2.id), // Drop on dynCol2
+      delta: { x: 0, y: 0 },
+      collisions: null,
+      activatorEvent: {} as any,
+    };
+
+    act(() => {
+      dndContextProps.onDragEnd(dragEndEvent);
+    });
+
+    // 3. Verify feedback message appears
+    const feedbackMessage = await screen.findByRole('status'); // role="status" was added
+    expect(feedbackMessage).toBeInTheDocument();
+    expect(feedbackMessage).toHaveTextContent(`${choreDefForInstX!.title} moved to ${dynamicCol2.title}.`);
+    expect(feedbackMessage).toHaveClass('kanban-action-feedback');
+
+    // 4. Advance timers to trigger message clearance
+    act(() => {
+      vi.advanceTimersByTime(3000); // Match the setTimeout duration in KidKanbanBoard
+    });
+
+    // 5. Verify feedback message is gone
     expect(screen.queryByRole('status')).not.toBeInTheDocument();
-    vi.useRealTimers(); 
+    expect(screen.queryByText(`${choreDefForInstX!.title} moved to ${dynamicCol2.title}.`)).not.toBeInTheDocument();
+
+    vi.useRealTimers(); // Restore real timers
   });
+
 });

--- a/src/ui/kanban_components/KidKanbanBoard.tsx
+++ b/src/ui/kanban_components/KidKanbanBoard.tsx
@@ -5,7 +5,7 @@
  * for chore reordering (persisted via ChoresContext) and moving chores
  * between these dynamic columns (updating choreInstance.kanbanColumnId via ChoresContext).
  */
-import React, { useState, useEffect, useMemo, useCallback } from 'react';
+import React, { useState, useEffect, useMemo, useCallback } from 'react'; // Added useCallback
 import { useChoresContext } from '../../contexts/ChoresContext';
 import { useUserContext } from '../../contexts/UserContext';
 import type { ChoreDefinition, ChoreInstance, KanbanPeriod, KanbanColumn as KanbanColumnType, ColumnThemeOption, MatrixKanbanCategory } from '../../types'; // Added MatrixKanbanCategory
@@ -126,7 +126,7 @@ const KidKanbanBoard: React.FC<KidKanbanBoardProps> = ({ kidId }) => {
 
   /** Memoized calculation of the date range for the selected period. */
   const currentPeriodDateRange = useMemo(() => {
-    const today = new Date(); // Use today for base, then adjust based on selectedPeriod for fixed ranges
+    const today = new Date();
     if (selectedPeriod === 'daily') {
       const todayStr = getTodayDateString();
       return { start: todayStr, end: todayStr };
@@ -179,8 +179,8 @@ const KidKanbanBoard: React.FC<KidKanbanBoardProps> = ({ kidId }) => {
     const userColumnConfigs = getKanbanColumnConfigs(kidId);
     const sortedUserColumnConfigs = [...userColumnConfigs].sort((a,b) => a.order - b.order);
     const defaultKanbanColumnId = sortedUserColumnConfigs.length > 0
-                                   ? sortedUserColumnConfigs[0].id
-                                   : undefined;
+                                  ? sortedUserColumnConfigs[0].id
+                                  : undefined;
     if (currentPeriodDateRange.start && currentPeriodDateRange.end) {
       generateInstancesForPeriod(
         currentPeriodDateRange.start,
@@ -220,8 +220,8 @@ const KidKanbanBoard: React.FC<KidKanbanBoardProps> = ({ kidId }) => {
     const kidAndPeriodInstances = choreInstances.filter(instance => {
       const definition = choreDefinitions.find(def => def.id === instance.choreDefinitionId);
       return definition && definition.assignedKidId === kidId &&
-                   instance.instanceDate >= currentPeriodDateRange.start &&
-                   instance.instanceDate <= currentPeriodDateRange.end;
+             instance.instanceDate >= currentPeriodDateRange.start &&
+             instance.instanceDate <= currentPeriodDateRange.end;
     });
 
     const filteredInstancesOverall = kidAndPeriodInstances.filter(instance => {
@@ -291,6 +291,13 @@ const KidKanbanBoard: React.FC<KidKanbanBoardProps> = ({ kidId }) => {
 
   const getDefinitionForInstance = useCallback((instance: ChoreInstance): ChoreDefinition | undefined => {
     return choreDefinitions.find(def => def.id === instance.choreDefinitionId);
+  };
+
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+  );
+
   }, [choreDefinitions]); // Added choreDefinitions dependency
 
   const sensors = useSensors(
@@ -314,13 +321,8 @@ const KidKanbanBoard: React.FC<KidKanbanBoardProps> = ({ kidId }) => {
   }, [choreInstances, getDefinitionForInstance]);
 
   const handleDragEnd = useCallback((event: DragEndEvent) => {
-    // Logic from the 'main' branch, integrated into the prioritized 'useCallback' structure.
-    // This captures the dragged item and clears the active state, which is important for UI feedback.
-    const currentActiveDragItem = activeDragItem;
-    setActiveDragItem(null);
-
     const { active, over } = event;
-    // setActiveDragItem(null); // Already handled above
+    setActiveDragItem(null); // Clear overlay item regardless of drop outcome
 
     if (!over || !active) {
       return;
@@ -366,7 +368,7 @@ const KidKanbanBoard: React.FC<KidKanbanBoardProps> = ({ kidId }) => {
     // if `SortableContext` is used per swimlane and items are reordered.
     // For now, the main goal is category change.
 
-  }, [activeDragItem, setActiveDragItem, choreInstances, updateChoreInstanceCategory, getDefinitionForInstance, setActionFeedbackMessage]);
+  }, [choreInstances, updateChoreInstanceCategory, getDefinitionForInstance, setActionFeedbackMessage]);
 
   const handleDragCancel = useCallback(() => {
     setActiveDragItem(null);
@@ -446,7 +448,7 @@ const KidKanbanBoard: React.FC<KidKanbanBoardProps> = ({ kidId }) => {
         </div>
 
         {/* Current Period Display (e.g., "Week: Sep 10, 2023 - Sep 16, 2023") - Kept from original */}
-        <div className="current-period-display" style={{ marginBottom: '15px', textAlign: 'center', fontWeight: 'bold', fontSize: '1.1em' }}>
+        <div className="current-period-display" style={{ marginBottom: '20px', textAlign: 'center', fontWeight: 'bold', fontSize: '1.1em' }}> {/* Increased marginBottom */}
           {currentPeriodDisplayString}
         </div>
 
@@ -468,10 +470,10 @@ const KidKanbanBoard: React.FC<KidKanbanBoardProps> = ({ kidId }) => {
                 if (newSortBy === 'rewardAmount') setSortDirection('desc');
                 else setSortDirection('asc');
                 // if (newSortBy !== 'instanceDate') { // This logic is tied to old kanbanChoreOrders
-                //    const currentKidColumns = getKanbanColumnConfigs(kidId);
-                //    currentKidColumns.forEach(config => {
-                //       updateKanbanChoreOrder(kidId, config.id, []);
-                //    });
+                //   const currentKidColumns = getKanbanColumnConfigs(kidId);
+                //   currentKidColumns.forEach(config => {
+                //     updateKanbanChoreOrder(kidId, config.id, []);
+                //   });
                 // }
               }} style={{ padding: '5px' }}>
               <option value="instanceDate">My Order / Due Date</option>


### PR DESCRIPTION
This commit delivers a significant portion of the Matrix Kanban functionality, including the data model, UI scaffolding, core logic for chore progression (manual drag-and-drop and automated via task completion), and initial UI refinements.

Key Changes:

1.  **Data Model (`src/types.ts`):**
    *   Introduced `MatrixKanbanCategory` ("TO_DO", "IN_PROGRESS", "COMPLETED").
    *   Enhanced `ChoreInstance` with:
        *   `instanceDate` for scheduling.
        *   `categoryStatus: MatrixKanbanCategory`.
        *   `taskCompletions: Record<string, boolean>` for instance-specific task states.
        *   `previousTaskCompletions?: Record<string, boolean>` for revert logic.
    *   Removed old `kanbanColumnId` from `ChoreInstance`.

2.  **Chores Context (`src/contexts/ChoresContext.tsx`):**
    *   Adapted to new `ChoreInstance` structure.
    *   Removed obsolete functions from the old Kanban model.
    *   `generateInstancesForPeriod`: Initializes new `ChoreInstance` fields.
    *   `toggleTaskCompletionOnInstance`: Updates task status on the instance and triggers automated category changes (e.g., "TO_DO" to "IN_PROGRESS", or any to "COMPLETED" if all tasks are done), including managing `previousTaskCompletions`.
    *   `updateChoreInstanceCategory`: Handles manual category changes (via D&D) and associated task state modifications (e.g., completing all tasks when moved to "COMPLETED", reverting state from "COMPLETED" to "IN_PROGRESS", clearing tasks when moved to "TO_DO").

3.  **UI Scaffolding & Components:**
    *   **`KidKanbanBoard.tsx`:**
        *   Redesigned for a 7-day navigable date timeline (horizontal axis) with date navigation controls ("Prev/Next Day/Week/Month", "Go to Today").
        *   Period selectors ("Daily", "Weekly", "Monthly") influence navigation jump granularity.
        *   Renders `DateColumnView` for visible dates.
    *   **`DateColumnView.tsx` (New):** Renders a column per date, hosting category swimlanes.
    *   **`CategorySwimlaneView.tsx` (New):**
        *   Renders "TO_DO", "IN_PROGRESS", "COMPLETED" swimlanes within each date column.
        *   Acts as a droppable area for `dnd-kit`.
        *   Displays filtered chore cards.
        *   Includes visual feedback for drag-over (`isOver` state).
        *   Improved empty state message.
    *   **`KanbanCard.tsx`:**
        *   Adapted to use `instance.taskCompletions`.
        *   Task checkboxes correctly call `toggleTaskCompletionOnInstance`.
        *   Task DOM IDs are unique using instance ID.

4.  **Vertical Drag-and-Drop (`KidKanbanBoard.tsx`):**
    *   Implemented using `dnd-kit` for moving cards between category swimlanes within the same date.
    *   `onDragEnd` handler calls `ChoresContext.updateChoreInstanceCategory`.
    *   Includes `DragOverlay` for visual feedback.

5.  **UI Refinements (General):**
    *   Reviewed and improved styling for date headers, navigation elements, swimlane distinction, and card clarity.
    *   Ensured feedback messages for D&D operations.

This commit represents a foundational implementation of the Matrix Kanban. Further work will involve comprehensive testing and documentation.