### PR TITLE
refactor: Encapsulate modals, add dedicated hook/component tests

### DIFF
--- a/src/hooks/useChoreSelection.test.ts
+++ b/src/hooks/useChoreSelection.test.ts
@@ -1,0 +1,129 @@
+import { renderHook, act } from '@testing-library/react';
+import { useChoreSelection } from './useChoreSelection';
+
+describe('useChoreSelection Hook', () => {
+  test('initializes with an empty array for selectedInstanceIds', () => {
+    const { result } = renderHook(() => useChoreSelection());
+    expect(result.current.selectedInstanceIds).toEqual([]);
+  });
+
+  describe('toggleSelection action', () => {
+    test('adds an ID if it is not already selected and shouldBeSelected is true', () => {
+      const { result } = renderHook(() => useChoreSelection());
+      act(() => {
+        result.current.toggleSelection('id1', true);
+      });
+      expect(result.current.selectedInstanceIds).toEqual(['id1']);
+    });
+
+    test('adds multiple IDs', () => {
+      const { result } = renderHook(() => useChoreSelection());
+      act(() => {
+        result.current.toggleSelection('id1', true);
+      });
+      act(() => {
+        result.current.toggleSelection('id2', true);
+      });
+      expect(result.current.selectedInstanceIds).toEqual(['id1', 'id2']);
+    });
+
+    test('removes an ID if it is selected and shouldBeSelected is false', () => {
+      const { result } = renderHook(() => useChoreSelection());
+      act(() => {
+        result.current.toggleSelection('id1', true);
+      });
+      act(() => {
+        result.current.toggleSelection('id2', true);
+      });
+      act(() => {
+        result.current.toggleSelection('id1', false);
+      });
+      expect(result.current.selectedInstanceIds).toEqual(['id2']);
+    });
+
+    test('does not add an ID if it is already selected and shouldBeSelected is true', () => {
+      const { result } = renderHook(() => useChoreSelection());
+      act(() => {
+        result.current.toggleSelection('id1', true);
+      });
+      act(() => {
+        result.current.toggleSelection('id1', true); // Attempt to add again
+      });
+      expect(result.current.selectedInstanceIds).toEqual(['id1']);
+    });
+
+    test('does not remove an ID if it is not selected and shouldBeSelected is false', () => {
+      const { result } = renderHook(() => useChoreSelection());
+      act(() => {
+        result.current.toggleSelection('id1', true);
+      });
+      act(() => {
+        result.current.toggleSelection('id2', false); // Attempt to remove non-existent
+      });
+      expect(result.current.selectedInstanceIds).toEqual(['id1']);
+    });
+
+    test('handles toggling all items off', () => {
+      const { result } = renderHook(() => useChoreSelection());
+      act(() => result.current.toggleSelection('id1', true));
+      act(() => result.current.toggleSelection('id2', true));
+      act(() => result.current.toggleSelection('id1', false));
+      act(() => result.current.toggleSelection('id2', false));
+      expect(result.current.selectedInstanceIds).toEqual([]);
+    });
+  });
+
+  describe('clearSelection action', () => {
+    test('clears all selected IDs', () => {
+      const { result } = renderHook(() => useChoreSelection());
+      act(() => {
+        result.current.toggleSelection('id1', true);
+      });
+      act(() => {
+        result.current.toggleSelection('id2', true);
+      });
+      expect(result.current.selectedInstanceIds).toEqual(['id1', 'id2']); // Pre-condition
+      act(() => {
+        result.current.clearSelection();
+      });
+      expect(result.current.selectedInstanceIds).toEqual([]);
+    });
+
+    test('does nothing if no IDs are selected', () => {
+      const { result } = renderHook(() => useChoreSelection());
+      expect(result.current.selectedInstanceIds).toEqual([]); // Pre-condition
+      act(() => {
+        result.current.clearSelection();
+      });
+      expect(result.current.selectedInstanceIds).toEqual([]);
+    });
+  });
+
+  describe('setSelectedInstanceIds action', () => {
+    test('directly sets the selectedInstanceIds array', () => {
+      const { result } = renderHook(() => useChoreSelection());
+      const newSelection = ['idA', 'idB', 'idC'];
+      act(() => {
+        result.current.setSelectedInstanceIds(newSelection);
+      });
+      expect(result.current.selectedInstanceIds).toEqual(newSelection);
+      // Ensure it's a new array reference for immutability if that's important, though not explicitly tested here
+      // expect(result.current.selectedInstanceIds).not.toBe(newSelection); // This would fail if not cloned
+    });
+
+    test('can set to an empty array', () => {
+      const { result } = renderHook(() => useChoreSelection());
+      // First, add some items
+      act(() => {
+        result.current.toggleSelection('id1', true);
+      });
+      expect(result.current.selectedInstanceIds).toEqual(['id1']);
+
+      // Then set to empty
+      act(() => {
+        result.current.setSelectedInstanceIds([]);
+      });
+      expect(result.current.selectedInstanceIds).toEqual([]);
+    });
+  });
+});

--- a/src/hooks/useModalState.test.ts
+++ b/src/hooks/useModalState.test.ts
@@ -1,0 +1,64 @@
+import { renderHook, act } from '@testing-library/react';
+import { useModalState } from './useModalState';
+
+describe('useModalState Hook', () => {
+  test('initializes isModalVisible to false by default', () => {
+    const { result } = renderHook(() => useModalState());
+    expect(result.current.isModalVisible).toBe(false);
+  });
+
+  test('initializes isModalVisible to true if initialState is true', () => {
+    const { result } = renderHook(() => useModalState(true));
+    expect(result.current.isModalVisible).toBe(true);
+  });
+
+  describe('openModal action', () => {
+    test('sets isModalVisible to true when called and initially false', () => {
+      const { result } = renderHook(() => useModalState(false));
+      act(() => {
+        result.current.openModal();
+      });
+      expect(result.current.isModalVisible).toBe(true);
+    });
+
+    test('keeps isModalVisible true when called and already true', () => {
+      const { result } = renderHook(() => useModalState(true));
+      act(() => {
+        result.current.openModal();
+      });
+      expect(result.current.isModalVisible).toBe(true);
+    });
+  });
+
+  describe('closeModal action', () => {
+    test('sets isModalVisible to false when called and initially true', () => {
+      const { result } = renderHook(() => useModalState(true));
+      act(() => {
+        result.current.closeModal();
+      });
+      expect(result.current.isModalVisible).toBe(false);
+    });
+
+    test('keeps isModalVisible false when called and already false', () => {
+      const { result } = renderHook(() => useModalState(false));
+      act(() => {
+        result.current.closeModal();
+      });
+      expect(result.current.isModalVisible).toBe(false);
+    });
+  });
+
+  test('openModal and closeModal work sequentially', () => {
+    const { result } = renderHook(() => useModalState());
+    expect(result.current.isModalVisible).toBe(false); // Initial
+
+    act(() => result.current.openModal());
+    expect(result.current.isModalVisible).toBe(true); // After open
+
+    act(() => result.current.closeModal());
+    expect(result.current.isModalVisible).toBe(false); // After close
+
+    act(() => result.current.openModal());
+    expect(result.current.isModalVisible).toBe(true); // After re-open
+  });
+});

--- a/src/ui/kanban_components/BatchActionsToolbar.test.tsx
+++ b/src/ui/kanban_components/BatchActionsToolbar.test.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import BatchActionsToolbar from './BatchActionsToolbar';
+import { vi } from 'vitest';
+import '@testing-library/jest-dom';
+
+describe('BatchActionsToolbar Component', () => {
+  const mockOnClearSelection = vi.fn();
+  const mockOnOpenCategoryModal = vi.fn();
+  const mockOnOpenKidAssignmentModal = vi.fn();
+  const mockOnMarkComplete = vi.fn();
+  const mockOnMarkIncomplete = vi.fn();
+
+  const defaultProps = {
+    selectedCount: 2,
+    onClearSelection: mockOnClearSelection,
+    onOpenCategoryModal: mockOnOpenCategoryModal,
+    onOpenKidAssignmentModal: mockOnOpenKidAssignmentModal,
+    onMarkComplete: mockOnMarkComplete,
+    onMarkIncomplete: mockOnMarkIncomplete,
+  };
+
+  beforeEach(() => {
+    // Reset mocks before each test
+    vi.clearAllMocks();
+  });
+
+  test('renders correctly with selectedCount', () => {
+    render(<BatchActionsToolbar {...defaultProps} />);
+    // Text is "2 selected", split across elements, so match flexibly
+    expect(screen.getByText((content, element) => {
+      return element?.tagName.toLowerCase() === 'span' && content.startsWith(defaultProps.selectedCount.toString()) && content.includes('selected');
+    })).toBeInTheDocument();
+  });
+
+  test('renders all action buttons', () => {
+    render(<BatchActionsToolbar {...defaultProps} />);
+    expect(screen.getByRole('button', { name: /Clear Selection/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Change Swimlane/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Assign to Kid/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Mark as Complete/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Mark as Incomplete/i })).toBeInTheDocument();
+  });
+
+  test('calls onClearSelection when "Clear Selection" button is clicked', () => {
+    render(<BatchActionsToolbar {...defaultProps} />);
+    fireEvent.click(screen.getByRole('button', { name: /Clear Selection/i }));
+    expect(mockOnClearSelection).toHaveBeenCalledTimes(1);
+  });
+
+  test('calls onOpenCategoryModal when "Change Swimlane/Category" button is clicked', () => {
+    render(<BatchActionsToolbar {...defaultProps} />);
+    fireEvent.click(screen.getByRole('button', { name: /Change Swimlane/i }));
+    expect(mockOnOpenCategoryModal).toHaveBeenCalledTimes(1);
+  });
+
+  test('calls onOpenKidAssignmentModal when "Assign to Kid" button is clicked', () => {
+    render(<BatchActionsToolbar {...defaultProps} />);
+    fireEvent.click(screen.getByRole('button', { name: /Assign to Kid/i }));
+    expect(mockOnOpenKidAssignmentModal).toHaveBeenCalledTimes(1);
+  });
+
+  test('calls onMarkComplete when "Mark as Complete" button is clicked', () => {
+    render(<BatchActionsToolbar {...defaultProps} />);
+    fireEvent.click(screen.getByRole('button', { name: /Mark as Complete/i }));
+    expect(mockOnMarkComplete).toHaveBeenCalledTimes(1);
+  });
+
+  test('calls onMarkIncomplete when "Mark as Incomplete" button is clicked', () => {
+    render(<BatchActionsToolbar {...defaultProps} />);
+    fireEvent.click(screen.getByRole('button', { name: /Mark as Incomplete/i }));
+    expect(mockOnMarkIncomplete).toHaveBeenCalledTimes(1);
+  });
+
+  // Optional: Test for selectedCount = 0.
+  // The BatchActionsToolbar itself doesn't hide based on selectedCount;
+  // its parent KidKanbanBoard decides whether to render it.
+  // So, this test is just to ensure it renders text for 0 items if passed.
+  test('renders null when selectedCount is 0', () => {
+    const { container } = render(<BatchActionsToolbar {...defaultProps} selectedCount={0} />);
+    // The component returns null when selectedCount is 0
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/src/ui/kanban_components/CategoryChangeModal.test.tsx
+++ b/src/ui/kanban_components/CategoryChangeModal.test.tsx
@@ -1,0 +1,142 @@
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import CategoryChangeModal from './CategoryChangeModal';
+import { ChoresContext, ChoresContextType } from '../../contexts/ChoresContext';
+import { vi } from 'vitest';
+import '@testing-library/jest-dom';
+import type { MatrixKanbanCategory } from '../../types';
+
+const mockBatchUpdateChoreInstancesCategory = vi.fn();
+
+const mockChoresContextValue: Partial<ChoresContextType> = {
+  batchUpdateChoreInstancesCategory: mockBatchUpdateChoreInstancesCategory,
+};
+
+// Helper to wrap component with context provider
+const renderWithContext = (ui: React.ReactElement) => {
+  return render(
+    <ChoresContext.Provider value={mockChoresContextValue as ChoresContextType}>
+      {ui}
+    </ChoresContext.Provider>
+  );
+};
+
+describe('CategoryChangeModal Component', () => {
+  const mockOnClose = vi.fn();
+  const mockOnActionSuccess = vi.fn();
+  const defaultCategories: MatrixKanbanCategory[] = ['TO_DO', 'IN_PROGRESS', 'COMPLETED'];
+  const defaultSelectedInstanceIds = ['id1', 'id2'];
+
+  const defaultProps = {
+    isVisible: true,
+    onClose: mockOnClose,
+    onActionSuccess: mockOnActionSuccess,
+    selectedInstanceIds: defaultSelectedInstanceIds,
+    categories: defaultCategories,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('does not render when isVisible is false', () => {
+    renderWithContext(<CategoryChangeModal {...defaultProps} isVisible={false} />);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  test('renders correctly when isVisible is true', () => {
+    renderWithContext(<CategoryChangeModal {...defaultProps} />);
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText('Select New Swimlane/Category')).toBeInTheDocument();
+    defaultCategories.forEach(cat => {
+      expect(screen.getByRole('button', { name: cat.replace('_', ' ') })).toBeInTheDocument();
+    });
+    expect(screen.getByRole('button', { name: /Confirm/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Cancel/i })).toBeInTheDocument();
+  });
+
+  test('clicking a category button updates internal selection and button style', () => {
+    renderWithContext(<CategoryChangeModal {...defaultProps} />);
+    const todoButton = screen.getByRole('button', { name: /TO DO/i });
+    const inProgressButton = screen.getByRole('button', { name: /IN PROGRESS/i });
+
+    // Check initial style (assuming default is not selected style)
+    expect(todoButton).toHaveStyle('background-color: #f0f0f0'); // Example non-selected style
+
+    fireEvent.click(todoButton);
+    // Check TO_DO button is styled as selected
+    expect(todoButton).toHaveStyle('background-color: #4CAF50'); // Example selected style
+    expect(inProgressButton).toHaveStyle('background-color: #f0f0f0');
+
+
+    fireEvent.click(inProgressButton);
+    // Check IN_PROGRESS button is styled as selected, TO_DO is not
+    expect(inProgressButton).toHaveStyle('background-color: #4CAF50');
+    expect(todoButton).toHaveStyle('background-color: #f0f0f0');
+  });
+
+  test('Confirm button is initially disabled if no category selected, enabled after selection', () => {
+    renderWithContext(<CategoryChangeModal {...defaultProps} />);
+    const confirmButton = screen.getByRole('button', { name: /Confirm/i });
+    expect(confirmButton).toBeDisabled();
+
+    const todoButton = screen.getByRole('button', { name: /TO DO/i });
+    fireEvent.click(todoButton);
+    expect(confirmButton).not.toBeDisabled();
+  });
+
+  test('Confirm button is disabled if selectedInstanceIds is empty', () => {
+    renderWithContext(<CategoryChangeModal {...defaultProps} selectedInstanceIds={[]} />);
+    const confirmButton = screen.getByRole('button', { name: /Confirm/i });
+
+    // Select a category
+    const todoButton = screen.getByRole('button', { name: /TO DO/i });
+    fireEvent.click(todoButton);
+
+    expect(confirmButton).toBeDisabled(); // Still disabled due to empty selectedInstanceIds
+  });
+
+
+  test('clicking "Confirm" calls batchUpdate, onActionSuccess, and onClose', async () => {
+    mockBatchUpdateChoreInstancesCategory.mockResolvedValueOnce(undefined); // Mock successful promise
+    renderWithContext(<CategoryChangeModal {...defaultProps} />);
+
+    const todoButton = screen.getByRole('button', { name: /TO DO/i });
+    fireEvent.click(todoButton); // Select 'TO_DO'
+
+    const confirmButton = screen.getByRole('button', { name: /Confirm/i });
+    await act(async () => {
+      fireEvent.click(confirmButton);
+    });
+
+    expect(mockBatchUpdateChoreInstancesCategory).toHaveBeenCalledTimes(1);
+    expect(mockBatchUpdateChoreInstancesCategory).toHaveBeenCalledWith(defaultSelectedInstanceIds, 'TO_DO');
+    expect(mockOnActionSuccess).toHaveBeenCalledTimes(1);
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
+  });
+
+  // Removed test for alert when clicking confirm without selection,
+  // as the button should be disabled, and that disabled state is tested elsewhere.
+  // The alert is a defensive measure in code but not reachable via user click if disabled logic is correct.
+
+  test('clicking "Cancel" calls onClose and not others', () => {
+    renderWithContext(<CategoryChangeModal {...defaultProps} />);
+    const cancelButton = screen.getByRole('button', { name: /Cancel/i });
+    fireEvent.click(cancelButton);
+
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
+    expect(mockBatchUpdateChoreInstancesCategory).not.toHaveBeenCalled();
+    expect(mockOnActionSuccess).not.toHaveBeenCalled();
+  });
+
+  test('clicking overlay calls onClose (simulating modal dismiss)', () => {
+    renderWithContext(<CategoryChangeModal {...defaultProps} />);
+    // The dialog itself is the overlay in this structure due to how it's styled
+    const dialogElement = screen.getByRole('dialog');
+    fireEvent.click(dialogElement); // Click on the overlay part
+
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
+    expect(mockBatchUpdateChoreInstancesCategory).not.toHaveBeenCalled();
+    expect(mockOnActionSuccess).not.toHaveBeenCalled();
+  });
+});

--- a/src/ui/kanban_components/KidAssignmentModal.test.tsx
+++ b/src/ui/kanban_components/KidAssignmentModal.test.tsx
@@ -1,0 +1,196 @@
+import React from 'react';
+import { render, screen, fireEvent, act as reactAct } from '@testing-library/react'; // Renamed act to avoid conflict
+import KidAssignmentModal from './KidAssignmentModal';
+import { UserContext, UserContextType } from '../../contexts/UserContext';
+import { ChoresContext, ChoresContextType } from '../../contexts/ChoresContext';
+import { vi } from 'vitest';
+import '@testing-library/jest-dom';
+import type { Kid } from '../../types';
+
+const mockBatchAssignChoreDefinitionsToKid = vi.fn();
+const mockUserKids: Kid[] = [
+  { id: 'kid1', name: 'Kid One', age: 8, avatarFilename: 'avatar1.png', totalFunds: 10, kanbanColumnConfigs: [] },
+  { id: 'kid2', name: 'Kid Two', age: 10, avatarFilename: 'avatar2.png', totalFunds: 20, kanbanColumnConfigs: [] },
+];
+
+const mockUserContextValue: Partial<UserContextType> = {
+  user: {
+    id: 'user1',
+    username: 'Test User',
+    email: 'test@example.com',
+    kids: mockUserKids,
+    // settings, createdAt, updatedAt can be added if needed by component
+  },
+  // Other UserContext fields can be mocked if used by the component
+};
+
+const mockChoresContextValue: Partial<ChoresContextType> = {
+  batchAssignChoreDefinitionsToKid: mockBatchAssignChoreDefinitionsToKid,
+};
+
+// Helper to wrap component with context providers
+const renderWithContexts = (ui: React.ReactElement) => {
+  return render(
+    <UserContext.Provider value={mockUserContextValue as UserContextType}>
+      <ChoresContext.Provider value={mockChoresContextValue as ChoresContextType}>
+        {ui}
+      </ChoresContext.Provider>
+    </UserContext.Provider>
+  );
+};
+
+describe('KidAssignmentModal Component', () => {
+  const mockOnClose = vi.fn();
+  const mockOnActionSuccess = vi.fn();
+  const defaultSelectedDefinitionIds = ['defId1', 'defId2'];
+
+  const defaultProps = {
+    isVisible: true,
+    onClose: mockOnClose,
+    onActionSuccess: mockOnActionSuccess,
+    selectedDefinitionIds: defaultSelectedDefinitionIds,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('does not render when isVisible is false', () => {
+    renderWithContexts(<KidAssignmentModal {...defaultProps} isVisible={false} />);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  test('renders correctly when isVisible is true', () => {
+    renderWithContexts(<KidAssignmentModal {...defaultProps} />);
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText('Assign to Kid')).toBeInTheDocument();
+    expect(screen.getByRole('combobox')).toBeInTheDocument(); // The select element
+    mockUserKids.forEach(kid => {
+      expect(screen.getByRole('option', { name: kid.name })).toBeInTheDocument();
+    });
+    expect(screen.getByRole('option', { name: 'Unassign' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Confirm/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Cancel/i })).toBeInTheDocument();
+  });
+
+  test('selecting a kid updates internal state and dropdown value', () => {
+    renderWithContexts(<KidAssignmentModal {...defaultProps} />);
+    const selectElement = screen.getByRole('combobox');
+
+    fireEvent.change(selectElement, { target: { value: 'kid1' } });
+    expect((selectElement as HTMLSelectElement).value).toBe('kid1');
+
+    fireEvent.change(selectElement, { target: { value: 'UNASSIGNED' } });
+    expect((selectElement as HTMLSelectElement).value).toBe('UNASSIGNED');
+  });
+
+  test('Confirm button is initially disabled, enabled after selection', () => {
+    renderWithContexts(<KidAssignmentModal {...defaultProps} />);
+    const confirmButton = screen.getByRole('button', { name: /Confirm/i });
+    expect(confirmButton).toBeDisabled();
+
+    const selectElement = screen.getByRole('combobox');
+    fireEvent.change(selectElement, { target: { value: 'kid1' } });
+    expect(confirmButton).not.toBeDisabled();
+  });
+
+  test('Confirm button is disabled if selectedDefinitionIds is empty', () => {
+    renderWithContexts(<KidAssignmentModal {...defaultProps} selectedDefinitionIds={[]} />);
+    const confirmButton = screen.getByRole('button', { name: /Confirm/i });
+
+    // Select a kid
+    const selectElement = screen.getByRole('combobox');
+    fireEvent.change(selectElement, { target: { value: 'kid1' } });
+
+    expect(confirmButton).toBeDisabled(); // Still disabled due to empty selectedDefinitionIds
+  });
+
+  test('clicking "Confirm" calls batchAssign, onActionSuccess, and onClose with selected kid ID', async () => {
+    mockBatchAssignChoreDefinitionsToKid.mockResolvedValueOnce(undefined);
+    renderWithContexts(<KidAssignmentModal {...defaultProps} />);
+
+    const selectElement = screen.getByRole('combobox');
+    fireEvent.change(selectElement, { target: { value: 'kid1' } });
+
+    const confirmButton = screen.getByRole('button', { name: /Confirm/i });
+    await reactAct(async () => { // Use reactAct for async operations within tests
+        fireEvent.click(confirmButton);
+    });
+
+    expect(mockBatchAssignChoreDefinitionsToKid).toHaveBeenCalledTimes(1);
+    expect(mockBatchAssignChoreDefinitionsToKid).toHaveBeenCalledWith(defaultSelectedDefinitionIds, 'kid1');
+    expect(mockOnActionSuccess).toHaveBeenCalledTimes(1);
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
+  });
+
+  test('clicking "Confirm" calls batchAssign with null for "Unassign"', async () => {
+    mockBatchAssignChoreDefinitionsToKid.mockResolvedValueOnce(undefined);
+    renderWithContexts(<KidAssignmentModal {...defaultProps} />);
+
+    const selectElement = screen.getByRole('combobox');
+    fireEvent.change(selectElement, { target: { value: 'UNASSIGNED' } });
+
+    const confirmButton = screen.getByRole('button', { name: /Confirm/i });
+    await reactAct(async () => {
+        fireEvent.click(confirmButton);
+    });
+
+    expect(mockBatchAssignChoreDefinitionsToKid).toHaveBeenCalledTimes(1);
+    expect(mockBatchAssignChoreDefinitionsToKid).toHaveBeenCalledWith(defaultSelectedDefinitionIds, null);
+    expect(mockOnActionSuccess).toHaveBeenCalledTimes(1);
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
+  });
+
+  // Removed test for alert when clicking confirm without selection,
+  // as the button should be disabled, and that disabled state is tested elsewhere.
+  // The alert is a defensive measure in code but not reachable via user click if disabled logic is correct.
+
+  test('clicking "Cancel" calls onClose and not others', () => {
+    renderWithContexts(<KidAssignmentModal {...defaultProps} />);
+    const cancelButton = screen.getByRole('button', { name: /Cancel/i });
+    fireEvent.click(cancelButton);
+
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
+    expect(mockBatchAssignChoreDefinitionsToKid).not.toHaveBeenCalled();
+    expect(mockOnActionSuccess).not.toHaveBeenCalled();
+  });
+
+  test('useEffect resets selection when modal becomes visible after being hidden', () => {
+    const { rerender } = renderWithContexts(<KidAssignmentModal {...defaultProps} isVisible={false} />);
+    let selectElement = screen.queryByRole('combobox') as HTMLSelectElement | null;
+    expect(selectElement).toBeNull(); // Not visible
+
+    // Make it visible
+    rerender(
+      <UserContext.Provider value={mockUserContextValue as UserContextType}>
+        <ChoresContext.Provider value={mockChoresContextValue as ChoresContextType}>
+          <KidAssignmentModal {...defaultProps} isVisible={true} />
+        </ChoresContext.Provider>
+      </UserContext.Provider>
+    );
+    selectElement = screen.getByRole('combobox') as HTMLSelectElement;
+    expect(selectElement.value).toBe(""); // Initial value after becoming visible
+
+    // Select a kid
+    fireEvent.change(selectElement, { target: { value: 'kid1' } });
+    expect(selectElement.value).toBe('kid1');
+
+    // Hide and re-show the modal
+    rerender(
+      <UserContext.Provider value={mockUserContextValue as UserContextType}>
+        <ChoresContext.Provider value={mockChoresContextValue as ChoresContextType}>
+          <KidAssignmentModal {...defaultProps} isVisible={false} />
+        </ChoresContext.Provider>
+      </UserContext.Provider>
+    );
+     rerender(
+      <UserContext.Provider value={mockUserContextValue as UserContextType}>
+        <ChoresContext.Provider value={mockChoresContextValue as ChoresContextType}>
+          <KidAssignmentModal {...defaultProps} isVisible={true} />
+        </ChoresContext.Provider>
+      </UserContext.Provider>
+    );
+    selectElement = screen.getByRole('combobox') as HTMLSelectElement;
+    expect(selectElement.value).toBe(""); // Should be reset
+  });
+});


### PR DESCRIPTION
This commit enhances modal encapsulation and introduces dedicated unit tests for custom hooks and sub-components created in previous refactoring efforts.

**Refactoring:**

-   **Modal Encapsulation (`CategoryChangeModal.tsx`, `KidAssignmentModal.tsx`):**
    -   Modals now manage more of their internal state (e.g., selected category/kid).
    -   They interact directly with `ChoresContext` and `UserContext` for actions like batch updates or fetching kid lists.
    -   This reduces prop drilling from `KidKanbanBoard.tsx`, as it no longer needs to pass down numerous callbacks or detailed data for modal operation. `KidKanbanBoard` now primarily passes selected item IDs and handles post-action events like clearing selection.

**Testing:**

-   **Dedicated Hook Tests (`useChoreSelection.test.ts`, `useModalState.test.ts`):**
    -   Created new test suites for `useChoreSelection` and `useModalState`.
    -   These tests cover initial state, actions (toggling selection, clearing, opening/closing modals), and ensure the hooks behave correctly in isolation. (18 tests added)
-   **Dedicated Sub-Component Tests (`BatchActionsToolbar.test.tsx`, `CategoryChangeModal.test.tsx`, `KidAssignmentModal.test.tsx`):**
    -   Created new test suites for these UI sub-components.
    -   Tests verify correct rendering based on props, interaction with buttons, and that callback props are invoked as expected.
    -   Modal tests include checks for visibility, internal state management (for selections within the modal), and interaction with mocked context functions. (25 tests added)

**Overall:**
-   The codebase structure is improved by making modals more self-contained.
-   Test coverage is significantly increased for the new hooks and UI components, ensuring their reliability.
-   All existing and newly added tests (total 126 tests across 14 suites) are passing.