### PR TITLE
feat: Implement "Edit Scope" for recurring chore edits

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -89,7 +89,7 @@ export interface ChoreInstance {
   previousSubtaskCompletions?: Record<string, boolean>;
 
   // Optional: if reward is snapshotted per instance or can vary
-  // rewardAmount?: number;
+  overriddenRewardAmount?: number; // For instance-specific reward override
   // kanbanColumnId?: string; // Removed in favor of categoryStatus for Matrix Kanban
 }
 

--- a/src/ui/kanban_components/EditScopeModal.test.tsx
+++ b/src/ui/kanban_components/EditScopeModal.test.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import EditScopeModal from './EditScopeModal'; // Adjust path as necessary
+import { vi } from 'vitest';
+import '@testing-library/jest-dom';
+
+describe('EditScopeModal Component', () => {
+  const mockOnClose = vi.fn();
+  const mockOnConfirmScope = vi.fn();
+
+  const defaultProps = {
+    isVisible: true,
+    onClose: mockOnClose,
+    onConfirmScope: mockOnConfirmScope,
+    fieldName: 'due date',
+    newValue: '2024-12-25',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('does not render when isVisible is false', () => {
+    render(<EditScopeModal {...defaultProps} isVisible={false} />);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  test('renders correctly when isVisible is true', () => {
+    render(<EditScopeModal {...defaultProps} />);
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText('Confirm Edit Scope')).toBeInTheDocument();
+    // Custom text matcher for the paragraph due to dynamic content and whitespace
+    const pElement = screen.getByText((content, node) => {
+      const nodeText = node?.textContent || "";
+      return node?.tagName.toLowerCase() === 'p' &&
+        nodeText.includes("You've edited") &&
+        nodeText.includes(defaultProps.fieldName!) &&
+        nodeText.includes(`to "${defaultProps.newValue}"`) &&
+        nodeText.includes(". Apply this change to:");
+    });
+    expect(pElement).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /This instance only/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /This and all future instances/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Cancel/i })).toBeInTheDocument();
+  });
+
+  test('renders default fieldName and newValue when props are not provided', () => {
+    render(<EditScopeModal isVisible={true} onClose={mockOnClose} onConfirmScope={mockOnConfirmScope} />);
+    expect(screen.getByText(/You've edited the field to the new value. Apply this change to:/i)).toBeInTheDocument();
+  });
+
+  test('renders newValue correctly even for numbers (e.g. reward)', () => {
+    const propsWithNumber = {...defaultProps, fieldName:"reward", newValue: 10};
+    render(<EditScopeModal {...propsWithNumber} />);
+    const pElement = screen.getByText((content, node) => {
+      const nodeText = node?.textContent || "";
+      return node?.tagName.toLowerCase() === 'p' &&
+        nodeText.includes("You've edited") &&
+        nodeText.includes(propsWithNumber.fieldName!) &&
+        nodeText.includes(`to "${propsWithNumber.newValue}"`) &&
+        nodeText.includes(". Apply this change to:");
+    });
+    expect(pElement).toBeInTheDocument();
+  });
+
+
+  test('clicking "This instance only" button calls onConfirmScope with "instance"', () => {
+    render(<EditScopeModal {...defaultProps} />);
+    fireEvent.click(screen.getByRole('button', { name: /This instance only/i }));
+    expect(mockOnConfirmScope).toHaveBeenCalledWith('instance');
+    expect(mockOnConfirmScope).toHaveBeenCalledTimes(1);
+  });
+
+  test('clicking "This and all future instances" button calls onConfirmScope with "series"', () => {
+    render(<EditScopeModal {...defaultProps} />);
+    fireEvent.click(screen.getByRole('button', { name: /This and all future instances/i }));
+    expect(mockOnConfirmScope).toHaveBeenCalledWith('series');
+    expect(mockOnConfirmScope).toHaveBeenCalledTimes(1);
+  });
+
+  test('clicking "Cancel" button calls onClose', () => {
+    render(<EditScopeModal {...defaultProps} />);
+    fireEvent.click(screen.getByRole('button', { name: /Cancel/i }));
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
+  });
+
+  test('clicking overlay calls onClose (simulating modal dismiss)', () => {
+    render(<EditScopeModal {...defaultProps} />);
+    const dialogElement = screen.getByRole('dialog');
+    fireEvent.click(dialogElement); // Click on the overlay part (assuming modalOverlayStyle is on the dialog's parent)
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/ui/kanban_components/EditScopeModal.tsx
+++ b/src/ui/kanban_components/EditScopeModal.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+
+export type EditScope = 'instance' | 'series';
+
+interface EditScopeModalProps {
+  isVisible: boolean;
+  onClose: () => void;
+  onConfirmScope: (scope: EditScope) => void;
+  fieldName?: string;
+  newValue?: any;
+}
+
+// Basic styling (can be moved to a CSS file or use a global modal style)
+const modalOverlayStyle: React.CSSProperties = {
+  position: 'fixed', top: 0, left: 0, width: '100%', height: '100%',
+  backgroundColor: 'rgba(0,0,0,0.5)', display: 'flex',
+  alignItems: 'center', justifyContent: 'center', zIndex: 1060, // Higher z-index if other modals exist
+};
+const modalContentStyle: React.CSSProperties = {
+  background: 'white', padding: '20px', borderRadius: '8px',
+  minWidth: '350px', maxWidth: '500px', boxShadow: '0 4px 10px rgba(0,0,0,0.25)',
+  textAlign: 'center',
+};
+const buttonContainerStyle: React.CSSProperties = {
+  display: 'flex',
+  justifyContent: 'space-around', // Distribute buttons evenly
+  marginTop: '20px',
+  gap: '10px', // Add some space between buttons
+};
+const buttonStyle: React.CSSProperties = {
+  padding: '10px 15px',
+  border: '1px solid #ccc',
+  borderRadius: '4px',
+  cursor: 'pointer',
+  flex: 1, // Allow buttons to grow and share space
+};
+
+const EditScopeModal: React.FC<EditScopeModalProps> = ({
+  isVisible,
+  onClose,
+  onConfirmScope,
+  fieldName,
+  newValue,
+}) => {
+  if (!isVisible) {
+    return null;
+  }
+
+  const fieldDisplay = fieldName ? fieldName.replace(/([A-Z])/g, ' $1').toLowerCase() : 'the field';
+  const valueDisplay = newValue !== undefined && newValue !== null ? `"${String(newValue)}"` : 'the new value';
+
+  return (
+    <div style={modalOverlayStyle} onClick={onClose} role="dialog" aria-modal="true" aria-labelledby="edit-scope-modal-title">
+      <div style={modalContentStyle} onClick={(e) => e.stopPropagation()}>
+        <h3 id="edit-scope-modal-title" style={{ marginTop: 0, marginBottom: '15px' }}>Confirm Edit Scope</h3>
+        <p>
+          You've edited {fieldDisplay} to {valueDisplay}. Apply this change to:
+        </p>
+        <div style={buttonContainerStyle}>
+          <button
+            onClick={() => onConfirmScope('instance')}
+            style={{ ...buttonStyle, backgroundColor: '#4CAF50', color: 'white' }}
+          >
+            This instance only
+          </button>
+          <button
+            onClick={() => onConfirmScope('series')}
+            style={{ ...buttonStyle, backgroundColor: '#2196F3', color: 'white' }}
+          >
+            This and all future instances
+          </button>
+        </div>
+        <div style={{ marginTop: '10px' }}>
+          <button
+            onClick={onClose}
+            style={{ ...buttonStyle, backgroundColor: '#f0f0f0', width: 'calc(50% - 5px)' }} // Make cancel button take half width approx
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default React.memo(EditScopeModal);


### PR DESCRIPTION
This commit introduces functionality to allow you to choose the scope of your edits (instance-only or entire series) when modifying recurring chores directly on the Kanban card.

**Key Features & Changes:**

1.  **Edit Scope Modal (`EditScopeModal.tsx`):**
    - When editing the date or reward of a recurring chore instance via inline editing on `KanbanCard.tsx`, a modal now appears.
    - This modal prompts you to apply the change to:
        - "This instance only"
        - "This and all future instances" (series edit)

2.  **Series Edit Logic (`ChoresContext.tsx`):**
    - Added a new `updateChoreSeries` function to `ChoresContext`.
    - This function handles series-wide changes by:
        - Updating the base `ChoreDefinition` (e.g., its `dueDate` for series date shifts, or `rewardAmount`).
        - Removing future instances of the chore from the `fromDate` (the date of the edited instance) onwards. - Regenerating new future instances based on the updated definition.
    - The `fieldName` parameter in `updateChoreSeries` helps differentiate between updating simple fields (like reward) and more complex date-shifting operations.

3.  **Instance-Specific Reward Override (`ChoreInstance`):**
    - Added an optional `overriddenRewardAmount?: number` field to the `ChoreInstance` type in `src/types.ts`.
    - If you choose to edit the reward for "This instance only," this field is set on the specific `ChoreInstance`.
    - `KanbanCard.tsx` now displays `overriddenRewardAmount` (with an "(edited)" indicator) if present, otherwise it shows the `definition.rewardAmount`.
    - When initiating an inline reward edit, the input is pre-filled with the override if it exists.
    - If a series-wide reward edit is performed, the `overriddenRewardAmount` on the currently edited instance is cleared to ensure it inherits the new series reward.

4.  **`KanbanCard.tsx` Integration:**
    - Modified inline editing logic to show the `EditScopeModal` for recurring chores.
    - Implemented `handleConfirmEditScope` to call the appropriate context functions based on your choice:
        - `updateChoreInstanceField` for instance-only edits (including setting `overriddenRewardAmount`).
        - `updateChoreSeries` for series-wide edits.