### PR TITLE
fix: Consolidate duplicate type imports in DateColumnView

### DIFF
--- a/src/ui/kanban_components/DateColumnView.tsx
+++ b/src/ui/kanban_components/DateColumnView.tsx
@@ -3,9 +3,9 @@ import React, { useMemo } from 'react';
 import KanbanCard from './KanbanCard';
 import { useChoresContext } from '../../contexts/ChoresContext';
 import { useUserContext } from '../../contexts/UserContext';
-import type { MatrixKanbanCategory, ChoreInstance, ChoreDefinition } from '../../types';
-
 import type { MatrixKanbanCategory, ChoreInstance, ChoreDefinition, KanbanColumnConfig } from '../../types';
+
+// Duplicate import removed by consolidation above
 
 interface DateColumnViewProps {
   date: Date;


### PR DESCRIPTION
Resolved a Vite pre-transform error ("Identifier has already been declared") in `src/ui/kanban_components/DateColumnView.tsx` caused by duplicate type imports from `../../types`.

The types `MatrixKanbanCategory`, `ChoreInstance`, `ChoreDefinition`, and `KanbanColumnConfig` are now imported in a single statement.

All tests continue to pass after this change.