### PR TITLE
Fix: Wrap application with NotificationProvider

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import KanbanView from './ui/KanbanView';
 import { UserProvider } from './contexts/UserContext';
 import { FinancialProvider } from './contexts/FinancialContext';
 import { ChoresProvider } from './contexts/ChoresContext';
+import { NotificationProvider } from './contexts/NotificationContext';
 
 function App() {
   const [theme, setTheme] = useState('light'); // Default theme
@@ -28,9 +29,10 @@ function App() {
       <UserProvider>
         <FinancialProvider>
           <ChoresProvider>
-            <div>
-              <nav style={{
-                marginBottom: 'var(--spacing-md)', /* Using CSS var */
+            <NotificationProvider>
+              <div>
+                <nav style={{
+                  marginBottom: 'var(--spacing-md)', /* Using CSS var */
                 background: 'var(--surface-color-hover)', /* Using CSS var */
                 padding: 'var(--spacing-sm) var(--spacing-md)', /* Using CSS var */
                 display: 'flex',
@@ -66,7 +68,8 @@ function App() {
                 <Route path="/kanban" element={<KanbanView />} />
                 <Route path="*" element={<DashboardView />} />
               </Routes>
-            </div>
+              </div>
+            </NotificationProvider>
           </ChoresProvider>
         </FinancialProvider>
       </UserProvider>


### PR DESCRIPTION
Ensures that the `useNotification` hook can be used by any component within the application by providing the `NotificationContext` at the root level of the component tree.

This resolves the error "Uncaught Error: useNotification must be used within a NotificationProvider" that was occurring in components like `KanbanCard`.

The `NotificationProvider` has been added to `src/App.tsx`, wrapping the main application content. Other errors noted in the issue (JSON parsing and SVG viewBox issues in `content.js`, and Grammarly errors) were identified as originating from external browser extensions and are not addressed by this commit as they are outside the scope of the application's codebase.