### PR TITLE
feat: Implement advanced Kanban features and UI refinements

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,12 +8,13 @@ import ActivityMonitoringView from './ui/ActivityMonitoringView';
 import KidDetailView from './ui/KidDetailView';
 import ChoreManagementView from './ui/ChoreManagementView';
 import KanbanView from './ui/KanbanView';
-import { UserProvider } from './contexts/UserContext';
+import { UserProvider, useUserContext } from './contexts/UserContext'; // Import useUserContext
 import { FinancialProvider } from './contexts/FinancialContext';
 import { ChoresProvider } from './contexts/ChoresContext';
-import { NotificationProvider } from './contexts/NotificationContext';
+import { NotificationProvider } from './contexts/NotificationContext'; // Added import
 
 function App() {
+  const { user } = useUserContext(); // Get user from context
   const [theme, setTheme] = useState('light'); // Default theme
 
   const toggleTheme = () => {
@@ -29,7 +30,7 @@ function App() {
       <UserProvider>
         <FinancialProvider>
           <ChoresProvider>
-            <NotificationProvider>
+            <NotificationProvider> // Added wrapper
               <div>
                 <nav style={{
                   marginBottom: 'var(--spacing-md)', /* Using CSS var */
@@ -43,7 +44,9 @@ function App() {
                 <ul style={{ listStyleType: 'none', padding: 0, margin: 0, display: 'flex', gap: 'var(--spacing-md)' /* Using CSS var */ }}>
                   <li><Link to="/">Dashboard</Link></li>
                   <li><Link to="/funds">Funds Management</Link></li>
-                  <li><Link to="/settings">Settings</Link></li>
+                  {user && user.role === 'admin' && (
+                    <li><Link to="/settings">Settings</Link></li>
+                  )}
                   <li><Link to="/activity">Activity Monitoring</Link></li>
                   <li><Link to="/chores">Chores</Link></li>
                   <li><Link to="/kanban">Kanban Board</Link></li>
@@ -69,7 +72,7 @@ function App() {
                 <Route path="*" element={<DashboardView />} />
               </Routes>
               </div>
-            </NotificationProvider>
+            </NotificationProvider> // Added wrapper
           </ChoresProvider>
         </FinancialProvider>
       </UserProvider>

--- a/src/contexts/UserContext.tsx
+++ b/src/contexts/UserContext.tsx
@@ -13,6 +13,7 @@ export interface User {
   };
   createdAt?: string;
   updatedAt?: string;
+  role?: 'admin' | 'user';
 }
 
 export interface UserContextType {
@@ -26,7 +27,7 @@ export interface UserContextType {
   updateKid: (updatedKidData: Kid) => void;
   deleteKid: (kidId: string) => void;
   getKanbanColumnConfigs: (kidId: string) => KanbanColumnConfig[];
-  addKanbanColumnConfig: (kidId: string, title: string, color?: string) => Promise<void>;
+  addKanbanColumnConfig: (kidId: string, title: string, color?: string, isCompletedColumn?: boolean) => Promise<void>;
   updateKanbanColumnConfig: (updatedConfig: KanbanColumnConfig) => Promise<void>;
   deleteKanbanColumnConfig: (kidId: string, configId: string) => Promise<void>;
   reorderKanbanColumnConfigs: (kidId: string, orderedConfigs: KanbanColumnConfig[]) => Promise<void>;
@@ -54,9 +55,27 @@ export const UserProvider: React.FC<UserProviderProps> = ({ children }) => {
 
   useEffect(() => {
     setLoading(true);
+    const now = new Date().toISOString();
     const sampleKids: Kid[] = [
-      { id: 'kid1', name: 'Alice', totalFunds: 0, kanbanColumnConfigs: [] },
-      { id: 'kid2', name: 'Bob', totalFunds: 0, kanbanColumnConfigs: [] },
+      {
+        id: 'kid1',
+        name: 'Alice',
+        totalFunds: 0,
+        kanbanColumnConfigs: [
+          { id: 'kid1_col1', kidId: 'kid1', title: 'To Do', order: 0, color: '#FFDDC1', createdAt: now, updatedAt: now, isCompletedColumn: false },
+          { id: 'kid1_col2', kidId: 'kid1', title: 'In Progress', order: 1, color: '#C1FFD7', createdAt: now, updatedAt: now, isCompletedColumn: false },
+          { id: 'kid1_col3', kidId: 'kid1', title: 'Done', order: 2, color: '#C1D4FF', createdAt: now, updatedAt: now, isCompletedColumn: true }
+        ]
+      },
+      {
+        id: 'kid2',
+        name: 'Bob',
+        totalFunds: 0,
+        kanbanColumnConfigs: [
+          { id: 'kid2_col1', kidId: 'kid2', title: 'Pending', order: 0, createdAt: now, updatedAt: now, isCompletedColumn: false },
+          { id: 'kid2_col2', kidId: 'kid2', title: 'Finished', order: 1, createdAt: now, updatedAt: now, isCompletedColumn: true }
+        ]
+      },
     ];
     const sampleUser: User = {
       id: 'user123',
@@ -64,6 +83,7 @@ export const UserProvider: React.FC<UserProviderProps> = ({ children }) => {
       email: 'user@example.com',
       kids: sampleKids,
       settings: { theme: 'light' },
+      role: 'admin', // Added role
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
     };
@@ -92,14 +112,20 @@ export const UserProvider: React.FC<UserProviderProps> = ({ children }) => {
       }
     },
     addKid: (kidData: Omit<Kid, 'id' | 'kanbanColumnConfigs' | 'totalFunds'> & { totalFunds?: number }) => {
-      // console.log('Mock addKid called with:', kidData); // Optional: for debugging
       if (user) {
+        const now = new Date().toISOString();
+        const kidIdBase = `kid_${Date.now()}`; // More robust base for unique IDs
+
         const newKid: Kid = {
-          id: `kid${new Date().getTime()}`, // Simple unique ID
+          id: kidIdBase,
           name: kidData.name,
           totalFunds: kidData.totalFunds || 0,
-          kanbanColumnConfigs: [],
-          // Assuming other Kid properties are optional or have defaults
+          // Default Kanban Column Configs
+          kanbanColumnConfigs: [
+            { id: `${kidIdBase}_col_0`, kidId: kidIdBase, title: 'To Do', order: 0, color: '#FFAB91', createdAt: now, updatedAt: now, isCompletedColumn: false }, // Light Coral
+            { id: `${kidIdBase}_col_1`, kidId: kidIdBase, title: 'In Progress', order: 1, color: '#FFF59D', createdAt: now, updatedAt: now, isCompletedColumn: false }, // Light Yellow
+            { id: `${kidIdBase}_col_2`, kidId: kidIdBase, title: 'Done', order: 2, color: '#A5D6A7', createdAt: now, updatedAt: now, isCompletedColumn: true } // Light Green
+          ],
         };
         setUser({ ...user, kids: [...user.kids, newKid] });
         return newKid.id;
@@ -126,7 +152,7 @@ export const UserProvider: React.FC<UserProviderProps> = ({ children }) => {
       }
       return [];
     },
-    addKanbanColumnConfig: async (kidId: string, title: string, color?: string) => {
+    addKanbanColumnConfig: async (kidId: string, title: string, color?: string, isCompletedColumn?: boolean) => {
       if (!user) return;
       const kidIndex = user.kids.findIndex(k => k.id === kidId);
       if (kidIndex === -1) {
@@ -143,6 +169,7 @@ export const UserProvider: React.FC<UserProviderProps> = ({ children }) => {
         title,
         order: newOrder,
         color,
+        isCompletedColumn: !!isCompletedColumn, // Ensure boolean value
         createdAt: new Date().toISOString(),
         updatedAt: new Date().toISOString(),
       };
@@ -164,7 +191,9 @@ export const UserProvider: React.FC<UserProviderProps> = ({ children }) => {
 
       const kid = user.kids[kidIndex];
       const updatedConfigs = (kid.kanbanColumnConfigs || []).map(config =>
-        config.id === updatedConfig.id ? { ...updatedConfig, updatedAt: new Date().toISOString() } : config
+        config.id === updatedConfig.id
+          ? { ...config, ...updatedConfig, updatedAt: new Date().toISOString() } // Ensure existing fields are preserved if not in updatedConfig
+          : config
       );
 
       const updatedKids = [...user.kids];

--- a/src/types.ts
+++ b/src/types.ts
@@ -96,6 +96,7 @@ export interface ChoreInstance {
   priority?: 'Low' | 'Medium' | 'High'; // Can override definition's priority
   instanceComments?: Array<{ id: string; userId: string; userName: string; text: string; createdAt: string; }>;
   isSkipped?: boolean;
+  activityLog?: Array<{ timestamp: string; action: string; userId?: string; userName?: string; details?: string; }>;
 }
 
 /**
@@ -118,6 +119,8 @@ export interface KanbanColumnConfig {
   createdAt?: string;
   /** Optional: Timestamp for when this swimlane configuration was last updated. */
   updatedAt?: string;
+  /** Optional: Indicates if this column represents a "completed" state for chores. */
+  isCompletedColumn?: boolean;
 }
 
 // Keep existing Kanban types for now, they might need adjustment later

--- a/src/ui/kanban_components/DateColumnView.tsx
+++ b/src/ui/kanban_components/DateColumnView.tsx
@@ -7,14 +7,15 @@ import { useDroppable } from '@dnd-kit/core';
 
 interface DateColumnViewProps {
   date: Date;
-  statusColumn: KanbanColumnConfig; // Changed from category to statusColumn
+  statusColumn: KanbanColumnConfig;
   onEditChore?: (chore: ChoreDefinition) => void;
   kidId?: string;
   selectedInstanceIds: string[];
   onToggleSelection: (instanceId: string, isSelected: boolean) => void;
+  isToday?: boolean; // Added isToday prop
 }
 
-// Removed categoryDisplayTitles and categoryStyles as they are now dynamic
+// Removed categoryDisplayTitles and categoryStyles
 
 const DateColumnView: React.FC<DateColumnViewProps> = ({
   date,
@@ -50,20 +51,29 @@ const DateColumnView: React.FC<DateColumnViewProps> = ({
   const defaultTextColor = '#333333';
   const defaultBorderColor = '#CCCCCC';
 
+  let currentBackgroundColor = statusColumn.color || defaultBackgroundColor;
+  if (isOver) {
+    currentBackgroundColor = '#D3D3D3'; // Hover effect
+  }
+  // Note: isToday styling for individual DateColumnView is subtle,
+  // primary highlight is on the header and column container via KidKanbanBoard.
+  // Adding a specific border or slight background adjustment here if needed.
+
   const columnStyle = {
-    backgroundColor: isOver ? '#D3D3D3' : (statusColumn.color || defaultBackgroundColor),
-    color: defaultTextColor, // Assuming text color doesn't change with column color for now
-    borderLeft: `4px solid ${statusColumn.color ? statusColumn.color : defaultBorderColor}`, // Use column color for border too, or a contrasting one
-    // ... other styles from original (borderRadius, marginBottom, padding, minHeight, boxShadow, transition)
+    backgroundColor: currentBackgroundColor,
+    color: defaultTextColor,
+    borderLeft: `4px solid ${statusColumn.color || defaultBorderColor}`,
+    // Example: Add a subtle right border to each column inside a "today" container for emphasis
+    borderRight: isToday ? `1px dashed var(--primary-color-light, #7bceff)` : `1px solid transparent`,
   };
 
 
   return (
     <div
       ref={setNodeRef}
-      className={`swimlane-view swimlane-custom-${statusColumn.id}`} // More generic class name
+      className={`swimlane-view swimlane-custom-${statusColumn.id} ${isToday ? 'today' : ''}`}
       style={{
-        ...columnStyle, // Apply dynamic styles
+        ...columnStyle,
         borderRadius: 6,
         marginBottom: 8,
         padding: '8px 6px 8px 12px',


### PR DESCRIPTION
This commit delivers a significant set of enhancements to the Kanban board, focusing on richer column behaviors, improved card details, basic role-based access for settings, and several UI/UX improvements.

Key features include:

1.  **Refined 'Done' State and Chore Completion Automation:**
    - Kanban columns can now be designated as 'isCompletedColumn' via settings.
    - Moving cards to/from these 'Done' columns automatically updates the card's 'isComplete' status and manages chore completion states (e.g., completing all chores when moved to Done, restoring previous chore states when moved out).
    - Completing/uncompleting the last chore can now automatically move a card to/from a 'Done' column.
    - Batch completion operations also respect this 'Done' column logic.

2.  **Card Detail Enhancements:**
    - **Activity Log:** Each chore instance now maintains an activity log. Changes like status updates, comments, completion, skipping, and field edits are automatically logged with timestamps and user info. The log is viewable on the Kanban card.
    - **Direct Tag Editing:** Tags for a chore definition can now be edited directly from the Kanban card interface, providing a quicker way to manage tags.

3.  **Basic Admin Role for Settings:**
    - A 'role' ('admin' | 'user') has been added to the User model.
    - The main 'Settings' navigation link is now only visible to users with the 'admin' role (current mock user is admin). This restricts access to application settings, including Kanban column configuration.

4.  **UI/UX Refinements:**
    - The current day is now visually highlighted on the Kanban board's date headers and columns.
    - Deleting a Kanban column from settings now presents a more informative warning if the column contains cards for the selected kid.
    - New kids added to the system now automatically receive a default set of Kanban columns ('To Do', 'In Progress', 'Done'), improving the onboarding experience.
    - If a kid's board has no columns (e.g., if an admin deletes them all), admin users will see a direct link to the settings page to configure them.